### PR TITLE
Major feature: Stratification (e.g., taxonomy/function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Subsequently, Woltka is able to assign query sequences to functional units, as d
 
 Similarly, the output files are two functional profiles: `uniref.biom` and `process.biom`.
 
+One can also combine taxonomic and functional profilings in a **stratification** analysis. See [details](doc/stratify.md).
+
 ## Notes
 
 ### Citation

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -58,6 +58,12 @@ Option | Description
 `--coords`, `-c` | Reference gene coordinates on genomes.
 `--overlap`, | Read/gene overlapping percentage threshold. Default: 80.
 
+### Stratification
+
+Option | Description
+--- | ---
+`--stratify`, `-t` | Directory of read-to-feature maps for stratification. One file per sample.
+
 ### Output files
 
 Option | Description

--- a/doc/output.md
+++ b/doc/output.md
@@ -110,9 +110,7 @@ The flag `--name-as-id` also applies to the read maps (see [above](#file-formats
 
 To enable writing of read maps, add `--outmap <directory>` to the command line. Woltka will write one read map file per sample, named after the sample ID, to the directory. If there are multiple ranks (`--rank`) to which reads are classified, Woltka will write read maps at each rank in a separate subdirectory named by the particular rank.
 
-Read maps are typically large -- comparable to the original alignment files, since each read occupies one line. Therefore, Woltka compresses them by default
-
-`--outmap-zip`. Values are `none`, `gz`, `bz2` and `xz`.
+Read maps are typically large -- comparable to the original alignment files, since each read occupies one line. Therefore, Woltka by default compresses them using the gzip algorithm (extension: `.gz`). One can select compression method using the `--outmap-zip` parameters. Choices are `none`, `gz`, `bz2` and `xz`.
 
 For example, with command:
 

--- a/doc/stratify.md
+++ b/doc/stratify.md
@@ -21,7 +21,7 @@ woltka classify \
 
 The parameter `--outmap mapdir` will instruct Woltka to output read-to-taxon maps to the directory `mapdir`. These maps will serve as stratum labels for the second run:
 
-Step 2: Combined taxonomic/functional classification
+## Step 2: Combined taxonomic/functional classification
 ```
 woltka classify \
   -i align/bowtie2 \

--- a/doc/stratify.md
+++ b/doc/stratify.md
@@ -19,7 +19,7 @@ woltka classify \
   -o taxonomy.biom
 ```
 
-The parameter `--outmap mapdir` will instruct Woltka to output read-to-taxon maps to directory `mapdir`. These maps will serve as stratum labels for the second run:
+The parameter `--outmap mapdir` will instruct Woltka to output read-to-taxon maps to the directory `mapdir`. These maps will serve as stratum labels for the second run:
 
 Step 2: Combined taxonomic/functional classification
 ```

--- a/doc/stratify.md
+++ b/doc/stratify.md
@@ -1,0 +1,52 @@
+# Stratification
+
+It is a frequent need to combine two or more classification systems in one analysis. For example, in a typical shotgun metagenomics study, one not only needs the taxonomic composition and functional potential of whole samples, but also wants to know which functional genes are found in which taxonomic units. This is because in many scenarios, only proteins wrapped within the same cell can constitute metabolic pathways, and this information is only available when the _taxonomy_ and _function_ of each sequence are informed simultaneously.
+
+Woltka enables this analysis through a "**stratification**" function. A stratum (plural: strata) is a subset of data grouped under the same label. Woltka allows the user to label sequences using one classification system (e.g., taxonomy), then classify sequences under each label using another classification system (e.g., function). This design maximizes flexibility and modularity. It is not bond by particular classification levels or systems, but can also work with ecological niches, phenotypic features, and other classification methods that best address specific research goals.
+
+Here is an example workflow, based on the commands and [sample data](../woltka/tests/data) introduced in the [quick-start guide](../README.md#example-usage), with merely two small modifications.
+
+Step 1: Taxonomic classification.
+```
+woltka classify \
+  -i align/bowtie2 \
+  --map taxonomy/g2tid.txt \
+  --nodes taxonomy/nodes.dmp \
+  --names taxonomy/names.dmp \
+  --rank phylum \
+  --name-as-id \
+  --outmap mapdir \
+  -o taxonomy.biom
+```
+
+The parameter `--outmap mapdir` will instruct Woltka to output read-to-taxon maps to directory `mapdir`. These maps will serve as stratum labels for the second run:
+
+Step 2: Combined taxonomic/functional classification
+```
+woltka classify \
+  -i align/bowtie2 \
+  --coords function/coords.txt.xz \
+  --map function/uniref.map.xz \
+  --map function/go/process.tsv.xz \
+  --map-as-rank \
+  --rank process \
+  --stratify mapdir \
+  -o taxfunc.biom
+```
+
+The parameter `--stratify mapdir` will instruct Woltka to take the previously generated taxon maps under `mapdir` to label sequences during stratification.
+
+The output feature table is like:
+
+Feature ID | Sample 1 | Sample 2 | Sample 3 | Sample 4 |
+--- | --- | --- | --- | --- |
+Actinobacteria\|GO:0000003 | 10 | 6 | 2 | 0
+Actinobacteria\|GO:0000005 | 4 | 20 | 3 | 0
+Actinobacteria\|GO:0000006 | 0 | 12 | 5 | 2
+Bacteroidetes\|GO:0000003 | 105 | 0 | 0 | 0
+Bacteroidetes\|GO:0000005 | 75 | 3 | 0 | 5
+Bacteroidetes\|GO:0000006 | 80 | 2 | 0 | 2
+Firmicutes\|GO:0000003 | 8 | 0 | 0 | 35
+Firmicutes\|GO:0000005 | 0 | 0 | 2 | 32
+Firmicutes\|GO:0000006 | 0 | 0 | 0 | 18
+... |

--- a/doc/stratify.md
+++ b/doc/stratify.md
@@ -6,7 +6,7 @@ Woltka enables this analysis through a "**stratification**" function. A stratum 
 
 Here is an example workflow, based on the commands and [sample data](../woltka/tests/data) introduced in the [quick-start guide](../README.md#example-usage), with merely two small modifications.
 
-Step 1: Taxonomic classification.
+## Step 1: Taxonomic classification.
 ```
 woltka classify \
   -i align/bowtie2 \

--- a/doc/stratify.md
+++ b/doc/stratify.md
@@ -36,7 +36,7 @@ woltka classify \
 
 The parameter `--stratify mapdir` will instruct Woltka to take the previously generated taxon maps under `mapdir` to label sequences during stratification.
 
-The output feature table is like:
+The output feature table, `taxfunc.biom`, is formatted like:
 
 Feature ID | Sample 1 | Sample 2 | Sample 3 | Sample 4 |
 --- | --- | --- | --- | --- |

--- a/woltka/biom.py
+++ b/woltka/biom.py
@@ -56,17 +56,21 @@ def profile_to_biom(profile, samples=None, tree=None, rankdic=None,
         # generate metadata and observation
         stratum, feature = key if isinstance(key, tuple) else (None, key)
         obsrv, meta_ = feature, {}
+        # get feature name
         if namedic:
             name = namedic[feature] if feature in namedic else None
             if name_as_id:
                 obsrv = name or feature
             else:
                 meta_['Name'] = name or None
+        # prefix with stratum label
         if stratum:
             obsrv = f'{stratum}|{obsrv}'
         observations.append(obsrv)
+        # get feature rank
         if rankdic:
             meta_['Rank'] = rankdic[feature] if feature in rankdic else None
+        # get lineage string
         if tree:
             meta_['Lineage'] = get_lineage_gg(
                 feature, tree, namedic if name_as_id else None) or None

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -154,16 +154,14 @@ def count_strata(matches, strata):
     for query, taxa in matches.items():
         if query in strata:
             feature = strata[query]
-        else:
-            continue
-        if isinstance(taxa, dict):
-            k = 1 / sum(taxa.values())
-            for taxon, n in taxa.items():
-                taxon = (feature, taxon)
-                res[taxon] = res.get(taxon, 0) + n * k
-        else:
-            taxon = (feature, taxa)
-            res[taxon] = res.get(taxon, 0) + 1
+            if isinstance(taxa, dict):
+                k = 1 / sum(taxa.values())
+                for taxon, n in taxa.items():
+                    taxon = (feature, taxon)
+                    res[taxon] = res.get(taxon, 0) + n * k
+            else:
+                taxon = (feature, taxa)
+                res[taxon] = res.get(taxon, 0) + 1
     return res
 
 

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -135,6 +135,38 @@ def count(matches):
     return res
 
 
+def count_strata(matches, strata):
+    """Stratify taxa in a map and count occurrences.
+
+    Parameters
+    ----------
+    matches : dict of str or dict
+        Query-to-taxon(a) map.
+    strata : dict, optional
+        Read-to-feature map for stratification.
+
+    Returns
+    -------
+    dict of tuple of (str, str): int
+        Stratified (feature, taxon): count map.
+    """
+    res = {}
+    for query, taxa in matches.items():
+        if query in strata:
+            feature = strata[query]
+        else:
+            continue
+        if isinstance(taxa, dict):
+            k = 1 / sum(taxa.values())
+            for taxon, n in taxa.items():
+                taxon = (feature, taxon)
+                res[taxon] = res.get(taxon, 0) + n * k
+        else:
+            taxon = (feature, taxa)
+            res[taxon] = res.get(taxon, 0) + 1
+    return res
+
+
 def majority(taxa, th=0.8):
     """Select taxon from list by majority rule.
 

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -141,6 +141,11 @@ def gotu(ctx, **kwargs):
 @click.option(
     '--overlap', type=click.IntRange(1, 100), default=80, show_default=True,
     help='Read/gene overlapping percentage threshold.')
+# stratification
+@click.option(
+    '--stratify', '-t', 'strata_dir',
+    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+    help='Directory of read-to-feature maps for stratification.')
 # output files
 @click.option(
     '--to-biom/--to-tsv', 'output_fmt', default=None,

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -26,14 +26,16 @@ ZIPDIC = {'.gz': gzip, '.gzip': gzip,
           '.xz': lzma, '.lz': lzma, '.lzma': lzma}
 
 
-def readzip(fp):
-    """Read a regular or compressed file by matching filename extension to
+def openzip(fp, mode='rt'):
+    """Open a regular or compressed file by matching filename extension to
     proper library.
 
     Parameters
     ----------
     fp : str
         Input filepath.
+    mode : str, optional
+        Python file mode. Default: "rt" (read as text).
 
     Returns
     -------
@@ -42,7 +44,7 @@ def readzip(fp):
     """
     ext = splitext(fp)[1]
     zipfunc = getattr(ZIPDIC[ext], 'open') if ext in ZIPDIC else open
-    return zipfunc(fp, 'rt')
+    return zipfunc(fp, mode)
 
 
 def file2stem(fname, ext=None):
@@ -203,7 +205,7 @@ def id2file_from_map(fp):
     """
     res = []
     fdir = dirname(fp)
-    with readzip(fp) as fh:
+    with openzip(fp) as fh:
         for line in fh:
             line = line.rstrip()
 

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -13,7 +13,7 @@ from os.path import join, dirname, realpath
 from shutil import rmtree
 from tempfile import mkdtemp
 
-from woltka.file import readzip
+from woltka.file import openzip
 from woltka.align import (
     parse_align_file, Plain, infer_align_format, assign_parser, parse_map_line,
     parse_b6o_line, parse_sam_line, cigar_to_lens, parse_kraken,
@@ -182,11 +182,11 @@ class AlignTests(TestCase):
 
         # real files
         # Bowtie2 (sam)
-        with readzip(join(self.datdir, 'align', 'bowtie2', 'S01.sam.xz')) as f:
+        with openzip(join(self.datdir, 'align', 'bowtie2', 'S01.sam.xz')) as f:
             self.assertEqual(infer_align_format(next(f)), 'sam')
 
         # BURST (b6o)
-        with readzip(join(self.datdir, 'align', 'burst', 'S01.b6.bz2')) as f:
+        with openzip(join(self.datdir, 'align', 'burst', 'S01.b6.bz2')) as f:
             self.assertEqual(infer_align_format(next(f)), 'b6o')
 
     def test_assign_parser(self):

--- a/woltka/tests/test_biom.py
+++ b/woltka/tests/test_biom.py
@@ -96,6 +96,23 @@ class BiomTests(TestCase):
                'Bacteria;Terra', None]
         assert_array_equal(obs, exp)
 
+        # with stratification
+        profile = {'S1': {('A', 'G1'): 4,
+                          ('A', 'G2'): 5,
+                          ('B', 'G1'): 8},
+                   'S2': {('A', 'G1'): 2,
+                          ('B', 'G1'): 3,
+                          ('B', 'G2'): 7},
+                   'S3': {('B', 'G3'): 3,
+                          ('C', 'G2'): 5}}
+        table = profile_to_biom(profile)
+        obs = table.to_dataframe(dense=True).astype(int)
+        data = [[4, 2, 0], [5, 0, 0], [8, 3, 0], [0, 7, 0], [0, 0, 3],
+                [0, 0, 5]]
+        index = ['A|G1', 'A|G2', 'B|G1', 'B|G2', 'B|G3', 'C|G2']
+        exp = pd.DataFrame(data, index=index, columns=samples)
+        assert_frame_equal(obs, exp)
+
     def test_write_biom(self):
         profile = {'S1': {'G1': 4, 'G2': 5, 'G3': 8},
                    'S2': {'G1': 2, 'G4': 3, 'G5': 7},

--- a/woltka/tests/test_file.py
+++ b/woltka/tests/test_file.py
@@ -21,7 +21,7 @@ from woltka.file import (
     id2file_from_map, read_map, write_readmap, write_table, prep_table)
 
 
-class UtilTests(TestCase):
+class FileTests(TestCase):
     def setUp(self):
         self.tmpdir = mkdtemp()
         self.datdir = join(dirname(realpath(__file__)), 'data')

--- a/woltka/tests/test_ordinal.py
+++ b/woltka/tests/test_ordinal.py
@@ -13,7 +13,7 @@ from os.path import join, dirname, realpath
 from shutil import rmtree
 from tempfile import mkdtemp
 
-from woltka.file import readzip
+from woltka.file import openzip
 from woltka.align import parse_b6o_line, parse_sam_line
 from woltka.ordinal import (
     Ordinal, match_read_gene, read_gene_coords, whether_prefix,
@@ -249,7 +249,7 @@ class OrdinalTests(TestCase):
 
         # real coords file
         fp = join(self.datdir, 'function', 'coords.txt.xz')
-        with readzip(fp) as f:
+        with openzip(fp) as f:
             obs = read_gene_coords(f, sort=True)
         self.assertEqual(len(obs), 107)
         obs_ = obs['G000006745']

--- a/woltka/tests/test_tree.py
+++ b/woltka/tests/test_tree.py
@@ -9,14 +9,13 @@
 # ----------------------------------------------------------------------------
 
 from unittest import TestCase, main
-from os import remove
 from os.path import join, dirname, realpath
 from shutil import rmtree
 from tempfile import mkdtemp
 
 from woltka.tree import (
-    read_names, read_nodes, read_lineage, read_newick, read_ranktb, read_map,
-    fill_root, get_lineage, get_lineage_gg, find_rank, find_lca)
+    read_names, read_nodes, read_lineage, read_newick, read_ranktb, fill_root,
+    get_lineage, get_lineage_gg, find_rank, find_lca)
 
 
 # A small test taxon set containing 15 proteobacterial species
@@ -152,30 +151,6 @@ class TreeTests(TestCase):
 
     def tearDown(self):
         rmtree(self.tmpdir)
-
-    def test_read_map(self):
-        # simple map
-        tsv = ('1	1',
-               '2	1',
-               '6	2	* notes')
-        fp = join(self.tmpdir, 'test.txt')
-        with open(fp, 'w') as f:
-            for line in tsv:
-                print(line, file=f)
-        with open(fp, 'r') as f:
-            obs = read_map(f)
-        exp = {'1': '1', '2': '1', '6': '2'}
-        self.assertDictEqual(obs, exp)
-        remove(fp)
-
-        # invalid format
-        with open(fp, 'w') as f:
-            print('hello', file=f)
-        with open(fp, 'r') as f:
-            with self.assertRaises(ValueError) as ctx:
-                obs = read_map(f)
-            self.assertEqual(str(ctx.exception), (
-                'Invalid mapping file format.'))
 
     def test_read_names(self):
         # simple map

--- a/woltka/tests/test_util.py
+++ b/woltka/tests/test_util.py
@@ -14,7 +14,8 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 from woltka.util import (
-    update_dict, add_dict, intize, delnone, allkeys, count_list, last_value)
+    add_dict, update_dict, sum_dict, intize, delnone, allkeys, count_list,
+    last_value, feat_n_cnt)
 
 
 class UtilTests(TestCase):
@@ -24,6 +25,17 @@ class UtilTests(TestCase):
 
     def tearDown(self):
         rmtree(self.tmpdir)
+
+    def test_add_dict(self):
+        d = {'a': 1, 'b': 2}
+        add_dict(d, 'c', 3)
+        self.assertDictEqual(d, {'a': 1, 'b': 2, 'c': 3})
+        add_dict(d, 'b', 2)
+        self.assertDictEqual(d, {'a': 1, 'b': 2, 'c': 3})
+        with self.assertRaises(AssertionError) as ctx:
+            add_dict(d, 'a', 0)
+        self.assertEqual(str(ctx.exception), (
+            'Conflicting values found for "a".'))
 
     def test_update_dict(self):
         d0 = {'a': 1, 'b': 2}
@@ -39,16 +51,16 @@ class UtilTests(TestCase):
         self.assertEqual(str(ctx.exception), (
             'Conflicting values found for "b".'))
 
-    def test_add_dict(self):
+    def test_sum_dict(self):
         d0 = {'a': 1, 'b': 2}
         d1 = {'c': 3, 'd': 4}
-        add_dict(d0, d1)
+        sum_dict(d0, d1)
         self.assertDictEqual(d0, {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         d2 = {'a': 1}
-        add_dict(d0, d2)
+        sum_dict(d0, d2)
         self.assertDictEqual(d0, {'a': 2, 'b': 2, 'c': 3, 'd': 4})
         d3 = {'e': 5, 'b': 3}
-        add_dict(d0, d3)
+        sum_dict(d0, d3)
         self.assertDictEqual(d0, {'a': 2, 'b': 5, 'c': 3, 'd': 4, 'e': 5})
 
     def test_intize(self):
@@ -92,6 +104,16 @@ class UtilTests(TestCase):
         lst = ['a', 1, None, 'b', 2, None]
         self.assertEqual(last_value(lst), 2)
         self.assertIsNone(last_value([None, None]))
+
+    def test_feat_n_cnt(self):
+        self.assertTupleEqual(feat_n_cnt('A'),   ('A', 1))
+        self.assertTupleEqual(feat_n_cnt('A:1'), ('A', 1))
+        self.assertTupleEqual(feat_n_cnt('A:2'), ('A', 2))
+        self.assertTupleEqual(feat_n_cnt('A:0'), ('A:0', 1))
+        self.assertTupleEqual(feat_n_cnt('A:x'), ('A:x', 1))
+        self.assertTupleEqual(feat_n_cnt(':1'),  (':1', 1))
+        self.assertTupleEqual(feat_n_cnt('::'),  ('::', 1))
+        self.assertTupleEqual(feat_n_cnt(''),    ('', 1))
 
 
 if __name__ == '__main__':

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -162,6 +162,27 @@ class WorkflowTests(TestCase):
         exp = [join(self.tmpdir, f'S{i}.sam') for i in range(1, 4)]
         self.assertListEqual(obs[1], exp)
 
+        # sample-to-file map
+        fp = join(self.tmpdir, 'sample.list')
+        with open(fp, 'w') as f:
+            for i in (range(1, 4)):
+                print(f'S{i}\tS{i}.sam', file=f)
+        obs = parse_samples(fp)
+        self.assertListEqual(obs[0], ['S1', 'S2', 'S3'])
+        exp = {join(self.tmpdir, f'S{i}.sam'): f'S{i}' for i in range(1, 4)}
+        self.assertDictEqual(obs[1], exp)
+
+        # some samples only
+        obs = parse_samples(fp, samples='S1,S2')
+        self.assertListEqual(obs[0], ['S1', 'S2'])
+
+        # some samples are not found
+        with self.assertRaises(ValueError) as ctx:
+            parse_samples(fp, samples='S1,S2,S4')
+        self.assertEqual(str(ctx.exception), (
+            'Provided sample IDs and actual files are inconsistent.'))
+        remove(fp)
+
         # not a valid path
         with self.assertRaises(ValueError) as ctx:
             parse_samples('im/not/path')

--- a/woltka/tree.py
+++ b/woltka/tree.py
@@ -45,33 +45,6 @@ code2rank['d'] = 'kingdom'
 notax = {'', '0', 'unclassified', 'unassigned'}
 
 
-def read_map(fh):
-    """Read simple low-to-high map from file.
-
-    Parameters
-    ----------
-    fh : file handle
-        Simple mapping file.
-
-    Returns
-    -------
-    dict
-        Mapping (mutually identical to a taxonomy tree).
-
-    Notes
-    -----
-    Only first two columns are considered.
-
-    TODO
-    ----
-    Support for one-to-multiple mappings.
-    """
-    try:
-        return dict(x.split('\t', 2)[:2] for x in fh.read().splitlines())
-    except ValueError:
-        raise ValueError('Invalid mapping file format.')
-
-
 def read_names(fh):
     """Read taxonomic names from a file.
 

--- a/woltka/util.py
+++ b/woltka/util.py
@@ -13,6 +13,39 @@ operations.
 """
 
 
+def add_dict(dic, key, value):
+    """Add a key-value pair to a dictionary while checking conflicts with
+    existing ones.
+
+    Parameters
+    ----------
+    dic : dict
+        Dictionary to add to.
+    key : hashable
+        Key to be added.
+    value : any
+        Value to be added.
+
+    Raises
+    ------
+    AssertionError
+        Key already exists and its value is different.
+
+    See Also
+    --------
+    update_dict
+
+    Notes
+    -----
+    The behaviors of "add" and "update" (see also "update_dict") are analogous
+    to Python set add() and update(), but with conflict checking.
+    """
+    try:
+        assert dic[key] == value, f'Conflicting values found for "{key}".'
+    except KeyError:
+        dic[key] = value
+
+
 def update_dict(dic, other):
     """Update one dictionary with another while checking conflicting items.
 
@@ -28,20 +61,22 @@ def update_dict(dic, other):
     AssertionError
         Two dictionaries have conflicting values of the same key.
 
+    See Also
+    --------
+    add_dict
+    sum_dict
+
     Notes
     -----
     If conflict-checking is not necessary, one should use Python's built-in
     method `update`.
     """
     for key, value in other.items():
-        try:
-            assert dic[key] == value, f'Conflicting values found for "{key}".'
-        except KeyError:
-            dic[key] = value
+        add_dict(dic, key, value)
 
 
-def add_dict(dic, other):
-    """Combine one dictionary with another, adding values for common keys.
+def sum_dict(dic, other):
+    """Merge one dictionary with another, adding values for common keys.
 
     Parameters
     ----------
@@ -49,6 +84,10 @@ def add_dict(dic, other):
         Dictionary to be updated.
     other : dict
         Dictionary as source of new items.
+
+    See Also
+    --------
+    update_dict
     """
     for key, value in other.items():
         dic[key] = dic.get(key, 0) + value
@@ -141,3 +180,45 @@ def last_value(lst):
         return next(x for x in reversed(lst) if x is not None)
     except StopIteration:
         pass
+
+
+def feat_n_cnt(s, sep=':'):
+    """Read feature and count from a string in format of "feature:count".
+
+    Parameters
+    ----------
+    s : str
+        Input string.
+    sep : str, optional
+        Separator between feature and count (default: colon).
+
+    Returns
+    -------
+    tuple of (str, int)
+        Pair of feature and count.
+    """
+    # find first occurrence of separator from right
+    key, _, value = s.rpartition(sep)
+
+    # if separator is found
+    if key:
+
+        # part after separator is number
+        try:
+            n = int(value)
+
+        # otherwise, entire string is feature
+        except ValueError:
+            return s, 1
+
+        # count must be positve integer
+        if n > 0:
+            return key, n
+
+        # otherwise, entire string is feature
+        else:
+            return s, 1
+
+    # no separator: entire string is feature
+    else:
+        return s, 1

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -200,13 +200,12 @@ def classify(mapper:  object,
         Per-rank profiles generated from classification.
     """
     data = {x: {} for x in ranks}
-    if outzip == 'none':
-        outzip = None
 
     # assignment parameters
     kwargs = {'tree': tree, 'rankdic': rankdic, 'root':  root, 'above': above,
               'major': major and major / 100, 'ambig': ambig, 'subok': subok,
-              'namedic': namedic, 'rank2dir': rank2dir, 'outzip': outzip}
+              'namedic': namedic, 'rank2dir': rank2dir, 'outzip': outzip if
+              outzip != 'none' else None}
 
     # current sample Id
     csample = None
@@ -685,9 +684,7 @@ def assign_readmap(rmap:     dict,
     # write classification map
     if rank2dir is not None:
         outfp = join(rank2dir[rank], f'{sample}.txt')
-        if outzip:
-            outfp = f'{outfp}.{outzip}'
-        with openzip(outfp, 'at') as fh:
+        with openzip(f'{outfp}.{outzip}' if outzip else outfp, 'at') as fh:
             write_readmap(fh, asgmt, namedic)
 
     # count taxa


### PR DESCRIPTION
This PR introduces a much demanded feature: **stratification**. This feature combines two classification systems in one analysis. A popular use case is taxonomic / functional profiling. Because functional genes typically form metabolic pathways within the same genome, analysis of metagenome should be informed by both taxonomy (i.e., genome) and function (i.e., gene) simultaneously. Previous, [HUMAnN2](http://huttenhower.sph.harvard.edu/humann) is well-known for performing this analysis.

The design of stratification in Woltka is as follows: First, run Woltka using one classification system (e.g., taxonomy), and choose to output read-to-taxon maps (using `--outmap <dir>`). Second, run Woltka again using another classification system (e.g., function), and take the previous maps to instruct stratification (using `--stratify <dir>`). This design is for flexibility and modularity.

The challenge of stratification is largely bonded by performance -- the program needs to match one map (sequence-to-taxonomy) and another (sequence-to-function), both are very huge files. The most efficient solution might be performing both analyses in memory in one run. However that will not guarantee flexibilty and modularity, therefore, for now, I choose to divide the analyses into two runs.

An example workflow is as follows (using bundled sample files):

Step 1: Taxonomic classification
```
woltka classify \
  -i align/bowtie2 \
  --map taxonomy/g2tid.txt \
  --nodes taxonomy/nodes.dmp \
  --names taxonomy/names.dmp \
  --rank phylum \
  --name-as-id \
  --outmap mapdir \
  -o taxonomy.biom
```

Step 2: Combined taxonomic/functional classification
```
woltka classify \
  -i align/bowtie2 \
  --coords function/coords.txt.xz \
  --map function/uniref.map.xz \
  --map function/go/process.tsv.xz \
  --map-as-rank \
  --rank process \
  --stratify mapdir \
  -o taxfunc.biom
```

The output feature table is like (note: the use of `|` follows HUMAnN2 convention):
```
#OTU ID S01     S02     S03     S04     S05
Actinobacteria|GO:0006071       2.0     0.0     0.0     0.0     0.0
Actinobacteria|GO:0006351       2.0     0.0     0.0     0.0     0.0
Actinobacteria|GO:0006412       0.0     0.0     0.0     0.0     2.0
Aquificae|GO:0000160    0.0     0.0     2.0     0.0     0.0
Aquificae|GO:0006011    0.0     0.0     2.0     0.0     0.0
Aquificae|GO:0006313    0.0     0.0     1.0     0.0     0.0
Bacteroidetes|GO:0006260        0.0     2.0     0.0     0.0     0.0
Bacteroidetes|GO:0006281        0.0     2.0     0.0     0.0     0.0
Bacteroidetes|GO:0006418        0.0     2.0     0.0     0.0     0.0
...
```