### PR TITLE
fixed zero-hit samples

### DIFF
--- a/woltka/biom.py
+++ b/woltka/biom.py
@@ -43,8 +43,10 @@ def profile_to_biom(profile, samples=None, tree=None, rankdic=None,
     biom.Table
         Converted BIOM table.
     """
-    samples = [x for x in samples if x in profile] if samples else sorted(
-        profile)
+    if samples:
+        samples = [x for x in samples if x in profile]
+    else:
+        samples = sorted(profile)
     observations, data, metadata = [], [], []
 
     for key in sorted(allkeys(profile)):

--- a/woltka/biom.py
+++ b/woltka/biom.py
@@ -18,14 +18,14 @@ from .tree import get_lineage_gg
 from .__init__ import __name__, __version__
 
 
-def profile_to_biom(profile, samples=None, tree=None, rankdic=None,
-                    namedic=None, name_as_id=False):
+def profile_to_biom(data, samples=None, tree=None, rankdic=None, namedic=None,
+                    name_as_id=False):
     """Convert a profile into a BIOM table.
 
     Parameters
     ----------
-    profile : dict
-        Profile to convert.
+    data : dict
+        Profile data to convert.
     samples : list of str, optional
         Sample ID list to include.
     tree : dict, optional
@@ -43,15 +43,14 @@ def profile_to_biom(profile, samples=None, tree=None, rankdic=None,
     biom.Table
         Converted BIOM table.
     """
-    # features = sorted(allkeys(profile))
-    samples = samples or sorted(profile)
+    samples = [x for x in samples if x in data] if samples else sorted(data)
     observations, data, metadata = [], [], []
 
-    for key in sorted(allkeys(profile)):
+    for key in sorted(allkeys(data)):
         # generate data
         row = []
         for sample in samples:
-            row.append(profile[sample][key] if key in profile[sample] else 0)
+            row.append(data[sample][key] if key in data[sample] else 0)
         data.append(row)
         # generate metadata and observation
         stratum, feature = key if isinstance(key, tuple) else (None, key)

--- a/woltka/biom.py
+++ b/woltka/biom.py
@@ -18,14 +18,14 @@ from .tree import get_lineage_gg
 from .__init__ import __name__, __version__
 
 
-def profile_to_biom(data, samples=None, tree=None, rankdic=None, namedic=None,
-                    name_as_id=False):
+def profile_to_biom(profile, samples=None, tree=None, rankdic=None,
+                    namedic=None, name_as_id=False):
     """Convert a profile into a BIOM table.
 
     Parameters
     ----------
-    data : dict
-        Profile data to convert.
+    profile : dict
+        Profile to convert.
     samples : list of str, optional
         Sample ID list to include.
     tree : dict, optional
@@ -43,14 +43,15 @@ def profile_to_biom(data, samples=None, tree=None, rankdic=None, namedic=None,
     biom.Table
         Converted BIOM table.
     """
-    samples = [x for x in samples if x in data] if samples else sorted(data)
+    samples = [x for x in samples if x in profile] if samples else sorted(
+        profile)
     observations, data, metadata = [], [], []
 
-    for key in sorted(allkeys(data)):
+    for key in sorted(allkeys(profile)):
         # generate data
         row = []
         for sample in samples:
-            row.append(data[sample][key] if key in data[sample] else 0)
+            row.append(profile[sample][key] if key in profile[sample] else 0)
         data.append(row)
         # generate metadata and observation
         stratum, feature = key if isinstance(key, tuple) else (None, key)

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -156,15 +156,16 @@ def id2file_from_dir(dir_, ext=None, ids=None):
     """
     res = {}
     for fname in listdir(dir_):
-        try:
-            id_ = file2stem(fname, ext)
-        except ValueError:
-            continue
-        if ids and id_ not in ids:
-            continue
-        if id_ in res:
-            raise ValueError(f'Ambiguous files for ID: "{id_}".')
-        res[id_] = fname
+        if isfile(join(dir_, fname)):
+            try:
+                id_ = file2stem(fname, ext)
+            except ValueError:
+                continue
+            if ids and id_ not in ids:
+                continue
+            if id_ in res:
+                raise ValueError(f'Ambiguous files for ID: "{id_}".')
+            res[id_] = fname
     return res
 
 

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -153,6 +153,11 @@ def id2file_from_dir(dir_, ext=None, ids=None):
     ------
     ValueError
         Multiple files have the same stem filename.
+
+    Notes
+    -----
+    Only top-level directory is searched. Only files but not subdirectories are
+    considered.
     """
     res = {}
     for fname in listdir(dir_):
@@ -364,7 +369,10 @@ def write_table(fh, data, samples=None, tree=None, rankdic=None, namedic=None,
     Optionally, three metadata columns, "Name", "Rank" and "Lineage" will be
     appended to the right of the table.
     """
-    samples = [x for x in samples if x in data] if samples else sorted(data)
+    if samples:
+        samples = [x for x in samples if x in data]
+    else:
+        samples = sorted(data)
 
     # table header
     header = ['#FeatureID'] + samples

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -363,7 +363,7 @@ def write_table(fh, data, samples=None, tree=None, rankdic=None, namedic=None,
     Optionally, three metadata columns, "Name", "Rank" and "Lineage" will be
     appended to the right of the table.
     """
-    samples = samples or sorted(data)
+    samples = [x for x in samples if x in data] if samples else sorted(data)
 
     # table header
     header = ['#FeatureID'] + samples

--- a/woltka/tests/test_biom.py
+++ b/woltka/tests/test_biom.py
@@ -51,6 +51,11 @@ class BiomTests(TestCase):
                            index=features, columns=['S3', 'S1'])
         assert_frame_equal(obs, exp)
 
+        # some sample Ids are not in profile
+        table = profile_to_biom(profile, samples=['S3', 'S0', 'S1'])
+        obs = table.to_dataframe(dense=True).astype(int)
+        assert_frame_equal(obs, exp)
+
         # with taxon names
         namedic = {'G1': 'Actinobacteria',
                    'G2': 'Firmicutes',

--- a/woltka/tests/test_file.py
+++ b/woltka/tests/test_file.py
@@ -120,7 +120,7 @@ class FileTests(TestCase):
         exp = {x: '{}.faa'.format(x) for x in ids}
         self.assertDictEqual(obs, exp)
 
-        # skip subdirectory
+        # skip subdirectory and only consider files
         sdir = join(self.tmpdir, 'im_dir')
         makedirs(sdir)
         obs = id2file_from_dir(self.tmpdir)
@@ -355,6 +355,13 @@ class FileTests(TestCase):
                'G3\t0\t8',
                'G4\t0\t0',
                'G5\t5\t0']
+        self.assertListEqual(obs, exp)
+
+        # some sample Ids are not in data
+        with open(fp, 'w') as f:
+            write_table(f, data, samples=['S3', 'S0', 'S1'])
+        with open(fp, 'r') as f:
+            obs = f.read().splitlines()
         self.assertListEqual(obs, exp)
 
         # with taxon names

--- a/woltka/tests/test_file.py
+++ b/woltka/tests/test_file.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 
 from unittest import TestCase, main
-from os import remove
+from os import remove, makedirs
 from os.path import join, dirname, realpath
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -119,6 +119,13 @@ class FileTests(TestCase):
         obs = id2file_from_dir(self.tmpdir)
         exp = {x: '{}.faa'.format(x) for x in ids}
         self.assertDictEqual(obs, exp)
+
+        # skip subdirectory
+        sdir = join(self.tmpdir, 'im_dir')
+        makedirs(sdir)
+        obs = id2file_from_dir(self.tmpdir)
+        self.assertDictEqual(obs, exp)
+        rmtree(sdir)
         for id_ in ids:
             remove(join(self.tmpdir, '{}.faa'.format(id_)))
 


### PR DESCRIPTION
Previously if a sample has no hit in the original alignment or after classification, the BIOM table won't generate, as @adswafford reported in issue #28 . This is a quick fix which will drop empty samples from the resulting table and avoid errors. Can anyone review this really quick to unblock the analyses? Thank you!

@gwarmstrong @fedarko @adswafford @emikoifish @swandro