### PR TITLE
Optimization of workflow

### DIFF
--- a/doc/classify.md
+++ b/doc/classify.md
@@ -8,7 +8,7 @@ Wolkta supports various formats of classification systems, specifically:
 
 2. `--newick`: Newick-format tree, in which labels of nodes (tips, internal nodes and root) are considered as taxa. All nodes must have labels and all labels must be unique.
 
-3. `--ranktb`: Table of per-taxon per-rank assignments. Each column represents a rank. Column header will be treated as rank name.
+3. `--rank-table`: Table of per-taxon per-rank assignments. Each column represents a rank. Column header will be treated as rank name.
 
 4. `--lineage`: Map of taxon to lineage string (`;`-delimited taxa from high to low)
 
@@ -20,7 +20,7 @@ Wolkta supports various formats of classification systems, specifically:
 
    One can supply multiple maps (by entering multiple `--map` parameters) to constitute several hierarchies. For example, the 1st file maps genes to UniRef entries, the 2nd maps UniRef entries to GO terms, the 3rd maps GO terms to GO slim terms, so on so forth.
 
-   Flag `--map-is-rank` is to instruct the program to treat the map filename as rank. For example, with this flag, taxa in the 2nd column of `uniref.map.gz` will be given the rank "uniref".
+   Flag `--map-as-rank` is to instruct the program to treat the map filename as rank. For example, with this flag, taxa in the 2nd column of `uniref.map.gz` will be given the rank "uniref".
 
 If no classification file is provided, Woltka will automatically build a classification system from the alignment files, in which subject identifiers will be parsed as lineage strings.
 
@@ -57,6 +57,9 @@ woltka classify \
   --names taxdump/names.dmp \
   ...
 ```
+
+One may supply multiple names files.
+
 
 ## Combined taxonomic & functional analyses
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -36,9 +36,9 @@ Option | Description
 `--newick` | Hierarchies defined by a tree in Newick format.
 `--lineage` | Map of lineage strings. Can accept Greengenes-style rank prefix.
 `--rank-table` | Table of classification units at each rank (column).
-`--map`, `-m` | Map(s) of subjects or lower classification units to higher ones. Can accept multiple maps.
+`--map`, `-m` | Map of lower classification units to higher ones. Can accept multiple files.
 `--map-as-rank` | Treat map filename stem as rank.
-`--names` | Names of classification units as defined by NCBI names.dmp or a plain map.
+`--names` | Names of classification units as defined by NCBI names.dmp or a plain map. Can accept multiple files.
 
 ### Assignment
 

--- a/woltka/align.py
+++ b/woltka/align.py
@@ -345,27 +345,19 @@ def cigar_to_lens(cigar):
         Alignment length.
     int
         Offset in subject sequence.
-
-    Raises
-    ------
-    ValueError
-        CIGAR string is missing.
     """
-    if cigar in ('', '*'):
-        raise ValueError('Missing CIGAR string.')
     align, offset = 0, 0
-    ops = 'DHIMNPSX='
     n = ''  # current step size
     for c in cigar:
-        if c in ops:
+        if c in 'MDIHNPSX=':
             if c in 'M=X':
                 align += int(n)
-            if c in 'MDN=X':
+            elif c in 'DN':
                 offset += int(n)
             n = ''
         else:
             n += c
-    return align, offset
+    return align, align + offset
 
 
 def parse_kraken(line):

--- a/woltka/align.py
+++ b/woltka/align.py
@@ -376,7 +376,7 @@ def parse_kraken(line):
     Notes
     -----
     Kraken2 output format:
-        C/U, sequence Id, taxonomy Id, length, LCA mapping
+        C/U, sequence ID, taxonomy ID, length, LCA mapping
 
     .. _Kraken2 manual:
         https://ccb.jhu.edu/software/kraken2/index.shtml?t=manual

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -100,10 +100,12 @@ def assign_rank(subs, rank, tree, rankdic, root=None, above=False, major=None,
     elif major:
         return majority(taxa, major)
     elif above:
+        if None in tset:
+            return None
         lca = find_lca(tset, tree)
         return None if lca == root else lca
     elif ambig:
-        return count_list(taxa)
+        return count_list(filter(None, taxa))
     else:
         return None
 

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -99,7 +99,7 @@ def gotu(ctx, **kwargs):
     '--lineage', 'lineage_fp', type=click.Path(exists=True),
     help='Map of lineage strings. Can accept Greengenes-style rank prefix.')
 @click.option(
-    '--rank-table', 'ranktbl_fp', type=click.Path(exists=True),
+    '--rank-table', 'rank_table_fp', type=click.Path(exists=True),
     help='Table of classification units at each rank (column).')
 @click.option(
     '--map', '-m', 'map_fps', type=click.Path(exists=True), multiple=True,

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -103,7 +103,7 @@ def gotu(ctx, **kwargs):
     help='Table of classification units at each rank (column).')
 @click.option(
     '--map', '-m', 'map_fps', type=click.Path(exists=True), multiple=True,
-    help=('Map of ower classification units to higher ones. Can accept '
+    help=('Map of lower classification units to higher ones. Can accept '
           'multiple files.'))
 @click.option(
     '--map-as-rank', is_flag=True,

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -103,8 +103,8 @@ def gotu(ctx, **kwargs):
     help='Table of classification units at each rank (column).')
 @click.option(
     '--map', '-m', 'map_fps', type=click.Path(exists=True), multiple=True,
-    help=('Map of subjects or lower classification units to higher ones. '
-          'Can accept multiple files.'))
+    help=('Map of ower classification units to higher ones. Can accept '
+          'multiple files.'))
 @click.option(
     '--map-as-rank', is_flag=True,
     help='Map filename stem is rank name.')

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -99,7 +99,7 @@ def gotu(ctx, **kwargs):
     '--lineage', 'lineage_fp', type=click.Path(exists=True),
     help='Map of lineage strings. Can accept Greengenes-style rank prefix.')
 @click.option(
-    '--rank-table', 'ranktb_fp', type=click.Path(exists=True),
+    '--rank-table', 'ranktbl_fp', type=click.Path(exists=True),
     help='Table of classification units at each rank (column).')
 @click.option(
     '--map', '-m', 'map_fps', type=click.Path(exists=True), multiple=True,

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -103,15 +103,15 @@ def gotu(ctx, **kwargs):
     help='Table of classification units at each rank (column).')
 @click.option(
     '--map', '-m', 'map_fps', type=click.Path(exists=True), multiple=True,
-    help=('Map(s) of subjects or lower classification units to higher ones. '
-          'Can accept multiple maps.'))
+    help=('Map of subjects or lower classification units to higher ones. '
+          'Can accept multiple files.'))
 @click.option(
     '--map-as-rank', is_flag=True,
     help='Map filename stem is rank name.')
 @click.option(
-    '--names', 'names_fp', type=click.Path(exists=True),
+    '--names', 'names_fps', type=click.Path(exists=True), multiple=True,
     help=('Names of classification units as defined by NCBI names.dmp or a '
-          'simple map.'))
+          'simple map. Can accept multiple files.'))
 # assignment
 @click.option(
     '--rank', '-r', 'ranks', type=click.STRING,

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -435,9 +435,9 @@ def prep_table(profile, samples=None):
     list of list
         Data (2D array of values).
     list
-        Index (observation Ids).
+        Index (observation IDs).
     list
-        Columns (sample Ids).
+        Columns (sample IDs).
 
     Notes
     -----

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -365,8 +365,10 @@ def write_table(fh, data, samples=None, tree=None, rankdic=None, namedic=None,
 
     Returns
     -------
-    int, int
-        Numbers of samples and features in the table, respectively.
+    int
+        Number of samples in the table.
+    int
+        Number of features in the table.
 
     Notes
     -----

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -363,6 +363,11 @@ def write_table(fh, data, samples=None, tree=None, rankdic=None, namedic=None,
         Replace feature IDs with names. It applies to row headers and "Lineage"
         column, and removes "Name" column.
 
+    Returns
+    -------
+    int, int
+        Numbers of samples and features in the table, respectively.
+
     Notes
     -----
     The output table will have columns as samples and rows as features.
@@ -385,6 +390,7 @@ def write_table(fh, data, samples=None, tree=None, rankdic=None, namedic=None,
     print('\t'.join(header), file=fh)
 
     # table body
+    nrow = 0
     for key in sorted(allkeys(data)):
         # stratification
         stratum, feature = key if isinstance(key, tuple) else (None, key)
@@ -408,6 +414,9 @@ def write_table(fh, data, samples=None, tree=None, rankdic=None, namedic=None,
                 feature, tree, namedic if name_as_id else None))
         # print row
         print('\t'.join(row), file=fh)
+        nrow += 1
+
+    return len(samples), nrow
 
 
 def prep_table(profile, samples=None):

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -215,7 +215,7 @@ def whether_prefix(coords):
     Returns
     -------
     bool
-        Whether gene Ids should be prefixed.
+        Whether gene IDs should be prefixed.
 
     See Also
     --------
@@ -317,7 +317,7 @@ def add_match_to_readmap(rmap, match, rids, nucl=None):
     rids : list
         Read ID list.
     nucl : str, optional
-        Prefix nucleotide Id to gene Ids.
+        Prefix nucleotide ID to gene IDs.
     """
     for idx, genes in match.items():
         if nucl:

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -257,11 +257,6 @@ class AlignTests(TestCase):
         self.assertTupleEqual(cigar_to_lens('150M'), (150, 150))
         self.assertTupleEqual(cigar_to_lens('3M1I3M1D5M'), (11, 12))
 
-        with self.assertRaises(ValueError) as context:
-            cigar_to_lens('*')
-        msg = 'Missing CIGAR string.'
-        self.assertEqual(str(context.exception), msg)
-
     def test_parse_kraken(self):
         kra = ('C	S1	561	150	561:100 A:10 562:40',
                'U	S2	0	150	1:80 A:40 0:20 A:10')

--- a/woltka/tests/test_classify.py
+++ b/woltka/tests/test_classify.py
@@ -96,6 +96,11 @@ class ClassifyTests(TestCase):
                           rankdic=rankdic, root=None, above=True)
         self.assertEqual(obs, 'T0')
 
+        # assign above rank but there is a None
+        obs = assign_rank({'G1', 'G2', 'G3', None}, 'general', tree=tree,
+                          rankdic=rankdic, root=None, above=True)
+        self.assertEqual(obs, None)
+
     def test_count(self):
         # unique match
         matches = {'seq1': 'a', 'seq2': 'a',  'seq3': 'b',

--- a/woltka/tests/test_file.py
+++ b/woltka/tests/test_file.py
@@ -332,7 +332,8 @@ class FileTests(TestCase):
                 'S3': {'G2': 3, 'G5': 5}}
         fp = join(self.tmpdir, 'profile.tsv')
         with open(fp, 'w') as f:
-            write_table(f, data)
+            obs = write_table(f, data)
+        self.assertTupleEqual(obs, (3, 5))
         with open(fp, 'r') as f:
             obs = f.read().splitlines()
         exp = ['#FeatureID\tS1\tS2\tS3',
@@ -346,7 +347,8 @@ class FileTests(TestCase):
         # with sample Ids
         samples = ['S3', 'S1']
         with open(fp, 'w') as f:
-            write_table(f, data, samples=samples)
+            obs = write_table(f, data, samples=samples)
+        self.assertTupleEqual(obs, (2, 5))
         with open(fp, 'r') as f:
             obs = f.read().splitlines()
         exp = ['#FeatureID\tS3\tS1',
@@ -359,7 +361,8 @@ class FileTests(TestCase):
 
         # some sample Ids are not in data
         with open(fp, 'w') as f:
-            write_table(f, data, samples=['S3', 'S0', 'S1'])
+            obs = write_table(f, data, samples=['S3', 'S0', 'S1'])
+        self.assertTupleEqual(obs, (2, 5))
         with open(fp, 'r') as f:
             obs = f.read().splitlines()
         self.assertListEqual(obs, exp)

--- a/woltka/tests/test_tree.py
+++ b/woltka/tests/test_tree.py
@@ -242,13 +242,13 @@ class TreeTests(TestCase):
         nwk = '((a,b),(c,d));'
         with self.assertRaises(ValueError) as ctx:
             read_newick((nwk,))
-        self.assertEqual(str(ctx.exception), 'Missing internal node Id.')
+        self.assertEqual(str(ctx.exception), 'Missing internal node ID.')
 
         # tree with duplicate node Ids
         nwk = '((a,b)x,(c,d)x)y;'
         with self.assertRaises(ValueError) as ctx:
             read_newick((nwk,))
-        self.assertEqual(str(ctx.exception), 'Found non-unique node Id: "x".')
+        self.assertEqual(str(ctx.exception), 'Found non-unique node ID: "x".')
 
         # proteo tree
         obs = read_newick((PROTEO['phylogeny'],))

--- a/woltka/tests/test_tree.py
+++ b/woltka/tests/test_tree.py
@@ -14,8 +14,8 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 from woltka.tree import (
-    read_names, read_nodes, read_lineage, read_newick, read_ranktb, fill_root,
-    get_lineage, get_lineage_gg, find_rank, find_lca)
+    read_names, read_nodes, read_lineage, read_newick, read_rank_table,
+    fill_root, get_lineage, get_lineage_gg, find_rank, find_lca)
 
 
 # A small test taxon set containing 15 proteobacterial species
@@ -273,14 +273,14 @@ class TreeTests(TestCase):
         self.assertEqual(obs['N2'], 'N1')
         self.assertEqual(obs['N1'], 'N1')
 
-    def test_read_ranktb(self):
+    def test_read_rank_table(self):
         # simple case
         tsv = ['#seq	k	p	c	o',
                'seq1	k1	p1	c1	o1',
                'seq2	k1	p1	c2	o2',
                'seq3	k1	p2	c3	',
                'seq4	k2		c4	o3']
-        tree_obs, rankdic_obs = read_ranktb(tsv)
+        tree_obs, rankdic_obs = read_rank_table(iter(tsv))
         tree_exp = {'seq1': 'o1', 'o1': 'c1', 'c1': 'p1', 'p1': 'k1',
                     'seq2': 'o2', 'o2': 'c2', 'c2': 'p1',
                     'seq3': 'c3', 'c3': 'p2', 'p2': 'k1',
@@ -295,18 +295,18 @@ class TreeTests(TestCase):
 
         # inconsistent tree
         with self.assertRaises(ValueError) as ctx:
-            read_ranktb(tsv + ['seq5	k1	p2	c1	o1'])
+            read_rank_table(iter(tsv + ['seq5	k1	p2	c1	o1']))
         self.assertEqual(str(ctx.exception), 'Conflict at taxon "c1".')
 
         # inconsistent rank
         with self.assertRaises(ValueError) as ctx:
-            read_ranktb(tsv + ['seq5	k2	c4		o3'])
+            read_rank_table(iter(tsv + ['seq5	k2	c4		o3']))
         self.assertEqual(str(ctx.exception), 'Conflict at taxon "c4".')
 
         # real rank table file
         fp = join(self.datdir, 'taxonomy', 'rank_tids.tsv')
         with open(fp, 'r') as f:
-            tree, rankdic = read_ranktb(f)
+            tree, rankdic = read_rank_table(f)
         self.assertEqual(len(tree), 426)
         self.assertEqual(len(rankdic), 319)
         self.assertEqual(tree['562'], '561')

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -256,7 +256,7 @@ class WorkflowTests(TestCase):
         fp = join(self.tmpdir, 'names.dmp')
         with open(fp, 'w') as f:
             f.write('a\tHomo\nb\tPan\nc\tChimp\n')
-        obs = build_hierarchy(names_fp=fp)
+        obs = build_hierarchy(names_fps=[fp])
         self.assertDictEqual(obs[2], {'a': 'Homo', 'b': 'Pan', 'c': 'Chimp'})
         remove(fp)
 

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -323,7 +323,7 @@ class WorkflowTests(TestCase):
                     'a\te\td\n'
                     'b\te\t\n'
                     'c\te\td\n')
-        obs = build_hierarchy(ranktbl_fp=fp)
+        obs = build_hierarchy(rank_table_fp=fp)
         self.assertDictEqual(obs[0], {
             'a': 'd', 'b': 'e', 'c': 'd', 'd': 'e', 'e': 'e'})
         self.assertDictEqual(obs[1], {'d': 'lv2', 'e': 'lv1'})

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -319,7 +319,7 @@ class WorkflowTests(TestCase):
                     'a\te\td\n'
                     'b\te\t\n'
                     'c\te\td\n')
-        obs = build_hierarchy(ranktb_fp=fp)
+        obs = build_hierarchy(ranktbl_fp=fp)
         self.assertDictEqual(obs[0], {
             'a': 'd', 'b': 'e', 'c': 'd', 'd': 'e', 'e': 'e'})
         self.assertDictEqual(obs[1], {'d': 'lv2', 'e': 'lv1'})

--- a/woltka/tree.py
+++ b/woltka/tree.py
@@ -60,7 +60,7 @@ def read_names(fh):
 
     Notes
     -----
-    Can be NCBI-style names.dmp or a plain map of Id to name.
+    Can be NCBI-style names.dmp or a plain map of ID to name.
     """
     names = {}
     for line in fh:
@@ -87,7 +87,7 @@ def read_nodes(fh):
 
     Notes
     -----
-    Input file can be NCBI-style nodes.dmp or a plain map of Id to parent and
+    Input file can be NCBI-style nodes.dmp or a plain map of ID to parent and
     (optional) rank.
     """
     tree, rankdic = {}, {}
@@ -117,9 +117,9 @@ def read_newick(fh):
     Raises
     ------
     ValueError
-        Missing internal node Id.
+        Missing internal node ID.
     ValueError
-        Found non-unique node Id.
+        Found non-unique node ID.
 
     Notes
     -----
@@ -152,12 +152,12 @@ def read_newick(fh):
         tail = nwk[m.end(0):]
         parent = _get_id(pend.split(tail, 1)[0])
         if parent == '':
-            raise ValueError('Missing internal node Id.')
+            raise ValueError('Missing internal node ID.')
 
         # get child Ids of current node
         for child in [_get_id(x) for x in m.group(0)[1:-1].split(',')]:
             if child in res:
-                raise ValueError(f'Found non-unique node Id: "{child}".')
+                raise ValueError(f'Found non-unique node ID: "{child}".')
             res[child] = parent
 
         # remove node from search string

--- a/woltka/tree.py
+++ b/woltka/tree.py
@@ -168,13 +168,13 @@ def read_newick(fh):
     return res
 
 
-def read_ranktb(fh):
+def read_rank_table(fh):
     """Read taxonomic information from a rank table.
 
     Parameters
     ----------
     fh : file handle
-        Taxonomic ranks file.
+        Rank table file.
 
     Returns
     -------
@@ -193,14 +193,13 @@ def read_ranktb(fh):
     For example, "Actinobacteria" is both a phylum and a class.
     """
     tree, rankdic = {}, {}
-    ranks = None
+
+    # get rank names from header
+    ranks = next(fh).rstrip().split('\t')[1:]
+
+    # ranks = None
     for line in fh:
         row = line.rstrip().split('\t')
-
-        # get rank names from header
-        if ranks is None:
-            ranks = row[1:]
-            continue
 
         # get lineage (taxa from high to low)
         lineage = [None if x in notax else x for x in row[1:]]

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -754,8 +754,9 @@ def write_profiles(data:        dict,
     else:
         # multiple output files
         makedirs(fp, exist_ok=True)
-        rank2fp = {x: join(fp, f'{x}.biom') for x in ranks}
         is_biom = is_biom is not False
+        ext = 'biom' if is_biom else 'tsv'
+        rank2fp = {x: join(fp, f'{x}.{ext}') for x in ranks}
     click.echo('Format of output feature table(s): {}.'.format(
         'BIOM' if is_biom else 'TSV'))
 

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -49,7 +49,7 @@ def workflow(input_fp:   str,
              ranktb_fp:    str = None,
              map_fps:     list = [],
              map_as_rank: bool = False,
-             names_fp:     str = None,
+             names_fps:   list = [],
              # assignment
              ranks:        str = None,
              above:       bool = False,
@@ -96,7 +96,7 @@ def workflow(input_fp:   str,
 
     # build classification system
     tree, rankdic, namedic, root = build_hierarchy(
-        names_fp, nodes_fp, newick_fp, lineage_fp, ranktb_fp, map_fps,
+        names_fps, nodes_fp, newick_fp, lineage_fp, ranktb_fp, map_fps,
         map_as_rank)
 
     # build mapping module
@@ -461,7 +461,7 @@ def prepare_ranks(ranks:      str = None,
     return ranks, rank2dir
 
 
-def build_hierarchy(names_fp:     str = None,
+def build_hierarchy(names_fps:   list = [],
                     nodes_fp:     str = None,
                     newick_fp:    str = None,
                     lineage_fp:   str = None,
@@ -472,8 +472,8 @@ def build_hierarchy(names_fp:     str = None,
 
     Parameters
     ----------
-    names_fp : str, optional
-        Taxonomic names file.
+    names_fps : list of str, optional
+        Taxonomic names file(s).
     nodes_fp : str, optional
         Taxonomic nodes file.
     newick_fp : str, optional
@@ -483,7 +483,7 @@ def build_hierarchy(names_fp:     str = None,
     ranktb_fp : str, optional
         Rank table file.
     map_fps : list of str, optional
-        Mapping files.
+        Mapping file(s).
     map_as_rank : bool, optional
         Treat mapping filename stem as rank.
 
@@ -500,15 +500,16 @@ def build_hierarchy(names_fp:     str = None,
     """
     tree, rankdic, namedic = {}, {}, {}
     is_build = any([
-        names_fp, nodes_fp, newick_fp, lineage_fp, ranktb_fp, map_fps])
+        names_fps, nodes_fp, newick_fp, lineage_fp, ranktb_fp, map_fps])
     if is_build:
         click.echo('Constructing classification system...')
 
     # taxonomy names
-    if names_fp:
-        click.echo(f'  Parsing taxonomy names file: {names_fp}...', nl=False)
-        with openzip(names_fp) as f:
-            namedic = read_names(f)
+    for fp in names_fps:
+        click.echo(f'  Parsing taxonomy names file: {fp}...', nl=False)
+        with openzip(fp) as f:
+            names = read_names(f)
+        update_dict(namedic, names)
         click.echo(' Done.')
 
     # taxonomy nodes

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -245,7 +245,7 @@ def classify(mapper:  object,
         click.echo(' Done.')
         click.echo(f'Number of query sequences: {n}.')
 
-    click.echo('Task completed.')
+    click.echo('Classification completed.')
     return data
 
 

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -243,7 +243,7 @@ def classify(mapper:  object,
                         assign_readmap(map_, data, rank, sample, **kwargs)
 
         click.echo(' Done.')
-        click.echo(f'Number of query sequences: {n}.')
+        click.echo(f'  Number of query sequences: {n}.')
 
     click.echo('Classification completed.')
     return data
@@ -763,15 +763,19 @@ def write_profiles(data:        dict,
         name_as_id = False
 
     # write output profile(s)
-    click.echo('Writing output profiles...', nl=False)
+    click.echo('Writing output profiles...')
     for rank, fp in rank2fp.items():
         if is_biom:
-            write_biom(profile_to_biom(
+            biom = profile_to_biom(
                 data[rank], samples, tree if add_lineage else None, rankdic
-                if add_rank else None, namedic, name_as_id), fp)
+                if add_rank else None, namedic, name_as_id)
+            write_biom(biom, fp)
+            m, n = biom.shape
         else:
             with open(fp, 'w') as fh:
-                write_table(
+                n, m = write_table(
                     fh, data[rank], samples, tree if add_lineage else None,
                     rankdic if add_rank else None, namedic, name_as_id)
-    click.echo(' Done.')
+        click.echo(f'  Rank: {rank}, samples: {n}, features: {m}.')
+
+    click.echo('Profiles written.')

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -29,7 +29,8 @@ from .classify import (
     assign_none, assign_free, assign_rank, count, count_strata, strip_index,
     demultiplex)
 from .tree import (
-    read_names, read_nodes, read_lineage, read_newick, read_ranktb, fill_root)
+    read_names, read_nodes, read_lineage, read_newick, read_rank_table,
+    fill_root)
 from .ordinal import Ordinal, read_gene_coords, whether_prefix
 from .biom import profile_to_biom, write_biom
 
@@ -46,7 +47,7 @@ def workflow(input_fp:   str,
              nodes_fp:     str = None,
              newick_fp:    str = None,
              lineage_fp:   str = None,
-             ranktb_fp:    str = None,
+             ranktbl_fp:   str = None,
              map_fps:     list = [],
              map_as_rank: bool = False,
              names_fps:   list = [],
@@ -96,7 +97,7 @@ def workflow(input_fp:   str,
 
     # build classification system
     tree, rankdic, namedic, root = build_hierarchy(
-        names_fps, nodes_fp, newick_fp, lineage_fp, ranktb_fp, map_fps,
+        names_fps, nodes_fp, newick_fp, lineage_fp, ranktbl_fp, map_fps,
         map_as_rank)
 
     # build mapping module
@@ -465,7 +466,7 @@ def build_hierarchy(names_fps:   list = [],
                     nodes_fp:     str = None,
                     newick_fp:    str = None,
                     lineage_fp:   str = None,
-                    ranktb_fp:    str = None,
+                    ranktbl_fp:    str = None,
                     map_fps:     list = [],
                     map_as_rank: bool = False) -> (dict, dict, dict, str):
     """Construct hierarchical classification system.
@@ -480,7 +481,7 @@ def build_hierarchy(names_fps:   list = [],
         Newick tree file.
     lineage_fp : str, optional
         Lineage strings file.
-    ranktb_fp : str, optional
+    ranktbl_fp : str, optional
         Rank table file.
     map_fps : list of str, optional
         Mapping file(s).
@@ -500,7 +501,7 @@ def build_hierarchy(names_fps:   list = [],
     """
     tree, rankdic, namedic = {}, {}, {}
     is_build = any([
-        names_fps, nodes_fp, newick_fp, lineage_fp, ranktb_fp, map_fps])
+        names_fps, nodes_fp, newick_fp, lineage_fp, ranktbl_fp, map_fps])
     if is_build:
         click.echo('Constructing classification system...')
 
@@ -538,10 +539,10 @@ def build_hierarchy(names_fps:   list = [],
         click.echo(' Done.')
 
     # rank table file
-    if ranktb_fp:
-        click.echo(f'  Parsing rank table file: {ranktb_fp}...', nl=False)
-        with openzip(ranktb_fp) as f:
-            tree_, rankdic_ = read_ranktb(f)
+    if ranktbl_fp:
+        click.echo(f'  Parsing rank table file: {ranktbl_fp}...', nl=False)
+        with openzip(ranktbl_fp) as f:
+            tree_, rankdic_ = read_rank_table(f)
             update_dict(tree, tree_)
             update_dict(rankdic, rankdic_)
         click.echo(' Done.')

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -349,7 +349,6 @@ def parse_samples(fp:        str,
     else:
         raise ValueError(f'"{fp}" is not a valid file or directory.')
 
-    click.echo(f'Number of alignment files to read: {len(files)}.')
     click.echo(f'Demultiplexing: {"on" if demux else "off"}.')
 
     return samples, files, demux

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -35,41 +35,41 @@ from .ordinal import Ordinal, read_gene_coords, whether_prefix
 from .biom import profile_to_biom, write_biom
 
 
-def workflow(input_fp:   str,
-             output_fp:  str,
+def workflow(input_fp:      str,
+             output_fp:     str,
              # input
-             input_fmt:    str = None,
-             input_ext:    str = None,
-             samples:      str = None,
-             demux:       bool = None,
-             lines:        int = 1000000,
+             input_fmt:     str = None,
+             input_ext:     str = None,
+             samples:       str = None,
+             demux:        bool = None,
+             lines:         int = 1000000,
              # hierarchies
-             nodes_fp:     str = None,
-             newick_fp:    str = None,
-             lineage_fp:   str = None,
-             ranktbl_fp:   str = None,
-             map_fps:     list = [],
-             map_as_rank: bool = False,
-             names_fps:   list = [],
+             nodes_fp:      str = None,
+             newick_fp:     str = None,
+             lineage_fp:    str = None,
+             rank_table_fp: str = None,
+             map_fps:      list = [],
+             map_as_rank:  bool = False,
+             names_fps:    list = [],
              # assignment
-             ranks:        str = None,
-             above:       bool = False,
-             major:       bool = None,
-             ambig:       bool = True,
-             subok:       bool = True,
-             deidx:       bool = False,
+             ranks:         str = None,
+             above:        bool = False,
+             major:        bool = None,
+             ambig:        bool = True,
+             subok:        bool = True,
+             deidx:        bool = False,
              # gene matching
-             coords_fp:    str = None,
-             overlap:      int = 80,
+             coords_fp:     str = None,
+             overlap:       int = 80,
              # stratification
-             strata_dir:   str = None,
+             strata_dir:    str = None,
              # output
-             output_fmt:   str = None,
-             name_as_id:  bool = False,
-             add_rank:    bool = False,
-             add_lineage: bool = False,
-             outmap_dir:   str = None,
-             outmap_zip:   str = 'gz') -> dict:
+             output_fmt:    str = None,
+             name_as_id:   bool = False,
+             add_rank:     bool = False,
+             add_lineage:  bool = False,
+             outmap_dir:    str = None,
+             outmap_zip:    str = 'gz') -> dict:
     """Main classification workflow which accepts command-line arguments.
 
     Returns
@@ -97,7 +97,7 @@ def workflow(input_fp:   str,
 
     # build classification system
     tree, rankdic, namedic, root = build_hierarchy(
-        names_fps, nodes_fp, newick_fp, lineage_fp, ranktbl_fp, map_fps,
+        names_fps, nodes_fp, newick_fp, lineage_fp, rank_table_fp, map_fps,
         map_as_rank)
 
     # build mapping module
@@ -462,13 +462,13 @@ def prepare_ranks(ranks:      str = None,
     return ranks, rank2dir
 
 
-def build_hierarchy(names_fps:   list = [],
-                    nodes_fp:     str = None,
-                    newick_fp:    str = None,
-                    lineage_fp:   str = None,
-                    ranktbl_fp:    str = None,
-                    map_fps:     list = [],
-                    map_as_rank: bool = False) -> (dict, dict, dict, str):
+def build_hierarchy(names_fps:    list = [],
+                    nodes_fp:      str = None,
+                    newick_fp:     str = None,
+                    lineage_fp:    str = None,
+                    rank_table_fp: str = None,
+                    map_fps:      list = [],
+                    map_as_rank:  bool = False) -> (dict, dict, dict, str):
     """Construct hierarchical classification system.
 
     Parameters
@@ -481,7 +481,7 @@ def build_hierarchy(names_fps:   list = [],
         Newick tree file.
     lineage_fp : str, optional
         Lineage strings file.
-    ranktbl_fp : str, optional
+    rank_table_fp : str, optional
         Rank table file.
     map_fps : list of str, optional
         Mapping file(s).
@@ -501,7 +501,7 @@ def build_hierarchy(names_fps:   list = [],
     """
     tree, rankdic, namedic = {}, {}, {}
     is_build = any([
-        names_fps, nodes_fp, newick_fp, lineage_fp, ranktbl_fp, map_fps])
+        names_fps, nodes_fp, newick_fp, lineage_fp, rank_table_fp, map_fps])
     if is_build:
         click.echo('Constructing classification system...')
 
@@ -539,9 +539,9 @@ def build_hierarchy(names_fps:   list = [],
         click.echo(' Done.')
 
     # rank table file
-    if ranktbl_fp:
-        click.echo(f'  Parsing rank table file: {ranktbl_fp}...', nl=False)
-        with openzip(ranktbl_fp) as f:
+    if rank_table_fp:
+        click.echo(f'  Parsing rank table file: {rank_table_fp}...', nl=False)
+        with openzip(rank_table_fp) as f:
             tree_, rankdic_ = read_rank_table(f)
             update_dict(tree, tree_)
             update_dict(rankdic, rankdic_)
@@ -735,6 +735,15 @@ def write_profiles(data:        dict,
         Append feature ranks to table.
     add_lineage: bool optional
         Append lineage strings to table.
+
+    Notes
+    -----
+    The boolean parameter `is_biom` can be one of the three values:
+    - `None` (default): To be auto-determined based on the user-supplied output
+    filename extension. If ".biom", do BIOM, otherwise do TSV. If output path is
+    a directory, do BIOM by default.
+    - `True` (command-line flag `--to-biom`): BIOM format.
+    - `False` (command-line flag `--to-tsv`): TSV format.
     """
     if not fp:
         return


### PR DESCRIPTION
This thread involves several optimizations aiming at reducing runtime which is current hours to days on large datasets (e.g., some hundreds of GB of alignment files), as well as bug fixes and trivial modifications. Currently, the changes are:

- [ ] CIGAR string parsing. Commit [64b8b69](https://github.com/qiyunzhu/woltka/pull/39/commits/64b8b69e9c0522ac8d7ee98c409f1f951dd51b10).
  - See issue #38 for details.
- [ ] Count list. Code is not changed but benchmarks are provided.
  - See added comment to issue #9 by @gwarmstrong.
- [ ] Avoided feature `None`. Commit [4635406](https://github.com/qiyunzhu/woltka/pull/39/commits/46354062e2f4a4c1a6af7d6b51e0e641d9be3765).
  - This bug partially caused the problem reported by @adswafford in issue #34. By default, Woltka allows sequences to be unclassified -- and they are assigned to taxon `None`. However `None` cannot be sorted together with string taxa. Therefore, this patch removes `None` from the resulting profiles.
- [ ] Allowed multiple `--names` files. Commit [ceecf64](https://github.com/qiyunzhu/woltka/pull/39/commits/ceecf64ac4a25dfabef80702f26f28dbdfcbfa9e).
  - A common use case is in functional classification. Each hierarchy (e.g., gene, module, pathway) has its own names file. Allowing them to be supplied simultaneously is favorable.
- [ ] Renamed `ranktb` as `rank_table`.
  - Also provided rationales in issue #16.
- [ ] Screen output enrichment. Commit [1ab7281](https://github.com/qiyunzhu/woltka/pull/39/commits/1ab728198bbe024cabb1b4615a1ccc4855833d2d).