### PR TITLE
Added documentation for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Woltka ships with a **QIIME 2 plugin**. [See here for instructions](woltka/q2).
 
 ## Installation
 
-Requirement: Python 3.6 or above.
+Requirement: [Python](https://www.python.org/) 3.6 or above, with Python package [biom-format](http://biom-format.org/).
 
 ```bash
 pip install git+https://github.com/qiyunzhu/woltka.git
@@ -49,6 +49,8 @@ After installation, launch the program by executing:
 ```bash
 woltka
 ```
+
+[More details about installation](doc/install.md) are provided here.
 
 ## Example usage
 

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,1 +1,2 @@
+cython
 biom-format

--- a/doc/install.md
+++ b/doc/install.md
@@ -7,9 +7,9 @@ There is no restriction as far as we are aware of. Tested and working on Linux, 
 
 ## Software environment
 
-Woltka is written in Python 3. One needs at least Python 3.6 to run the program.
+Woltka is written in **Python 3**. One needs at least Python 3.6 to run the program.
 
-We recommend [Conda](https://docs.conda.io/en/latest/) for managing Python version and packages. One can create a conda environment and install necessary dependencies by:
+We recommend [Conda](https://docs.conda.io/en/latest/) for managing Python version and packages. One can create a conda environment and install necessary dependencies (Cython and BIOM format) by:
 
 ```bash
 conda create -n woltka python=3
@@ -29,7 +29,7 @@ pip install git+https://github.com/qiyunzhu/woltka.git
 
 Option 2: Install from a local copy:
 
-Download this [repository](https://github.com/qiyunzhu/woltka/archive/master.zip). Unzip. Then execute:
+Download this [repository](https://github.com/qiyunzhu/woltka/archive/master.zip). Unzip and navigate to the package directory. Then execute:
 
 ```bash
 python setup.py install
@@ -45,6 +45,18 @@ Just add `--upgrade` or `-U` to the pip command:
 pip install -U git+https://github.com/qiyunzhu/woltka.git
 ```
 
+## Uninstallation
+
+```bash
+pip uninstall woltka
+```
+
+If you no longer need the conda environment:
+
+```bash
+conda env remove -n woltka --all
+```
+
 ## Compatibility
 
 If in the future some dependencies have changes that are not compatible with the current release of Woltka, the following "safe" commands can be used to install the current versions of dependencies.
@@ -54,3 +66,13 @@ conda create -n woltka python=3.8.2
 conda activate woltka
 conda install -c conda-forge cython=0.29.6 biom-format=2.1.8
 ```
+
+## Test
+
+You may test whether Woltka functions correctly by running it on some small test datasets. You will need to download the [repository](https://github.com/qiyunzhu/woltka/archive/master.zip) to get them. See [example usage](../README.md#example-usage) for how to run these small tests manually. Alternatively, you may execute the following command in the package directory:
+
+```bash
+python -m unittest
+```
+
+This will run all tests automatically. If it prints "OK" in the end, everything is okay. Otherwise it will report specific error(s), and in such case, please contact the development team for solutions.

--- a/doc/install.md
+++ b/doc/install.md
@@ -1,0 +1,56 @@
+# Installation
+
+## Operating system
+
+There is no restriction as far as we are aware of. Tested and working on Linux, macOS and Windows systems.
+
+
+## Software environment
+
+Woltka is written in Python 3. One needs at least Python 3.6 to run the program.
+
+We recommend [Conda](https://docs.conda.io/en/latest/) for managing Python version and packages. One can create a conda environment and install necessary dependencies by:
+
+```bash
+conda create -n woltka python=3
+conda activate woltka
+conda install -c conda-forge cython biom-format
+```
+
+If you already have a [QIIME 2](https://qiime2.org/) environment, these steps can be omitted as the dependencies are already included. See [details](../woltka/q2).
+
+## Installation
+
+Option 1: Install from GitHub:
+
+```bash
+pip install git+https://github.com/qiyunzhu/woltka.git
+```
+
+Option 2: Install from a local copy:
+
+Download this [repository](https://github.com/qiyunzhu/woltka/archive/master.zip). Unzip. Then execute:
+
+```bash
+python setup.py install
+```
+
+Type `woltka` to check if installation is successful, in which case command-line help information will be displayed on the screen.
+
+## Upgrade
+
+Just add `--upgrade` or `-U` to the pip command:
+
+```bash
+pip install -U git+https://github.com/qiyunzhu/woltka.git
+```
+
+## Compatibility
+
+If in the future some dependencies have changes that are not compatible with the current release of Woltka, the following "safe" commands can be used to install the current versions of dependencies.
+
+```bash
+conda create -n woltka python=3.8.2
+conda activate woltka
+conda install -c conda-forge cython=0.29.6 biom-format=2.1.8
+```

--- a/woltka/q2/README.md
+++ b/woltka/q2/README.md
@@ -11,7 +11,7 @@ Requires: QIIME 2 2019.1 or above.
 First, install the standalone Woltka program:
 
 ```bash
-pip install git+https://github.com/qiyunzhu/woltka.git@dev
+pip install git+https://github.com/qiyunzhu/woltka.git
 ```
 
 Second, update QIIME 2 cache and the plugin will be automatically loaded into QIIME 2.


### PR DESCRIPTION
The PR is purely documentation and has no code. Previously the instruction for installation is as simple as one pip command. However, the problem is that Woltka depends on `biom-format`, which, unfortunately cannot be `pip install`ed (it runs into `numpy` and `cython` dependency errors). Therefore, the practical solution is to first create a conda environment, then install `biom-format` as well as `cython` from conda channel `conda-forge`, then execute the woltka installation command. This instruction is now documented in a new markdown file [install.md](https://github.com/qiyunzhu/woltka/blob/install/doc/install.md). The document also includes operating system, manual installation, upgrade and other useful information. @adswafford @swandro @cameronmartino @gregpoore Feel free to leave any feedbacks!