### PR TITLE
Replaced `startswith` with `==`

### DIFF
--- a/woltka/align.py
+++ b/woltka/align.py
@@ -307,7 +307,7 @@ def parse_sam_line(line):
         http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#sam-output
     """
     # skip header
-    if line.startswith('@'):
+    if line[0] == '@':
         return
     x = line.rstrip().split('\t')
     qname, rname = x[0], x[2]  # query and subject identifiers

--- a/woltka/align.py
+++ b/woltka/align.py
@@ -189,7 +189,7 @@ def infer_align_format(line):
     parse_b6o_line
     parse_sam_line
     """
-    if line.split()[0] == '@HD':
+    if line.split()[0] in ('@HD', '@PG'):
         return 'sam'
     row = line.rstrip().split('\t')
     if len(row) == 2:

--- a/woltka/align.py
+++ b/woltka/align.py
@@ -281,7 +281,7 @@ def parse_b6o_line(line):
 
 
 def parse_sam_line(line):
-    """Parse a line in a SAM format (sam).
+    """Parse a line in a SAM file (sam).
 
     Parameters
     ----------


### PR DESCRIPTION
In function `parse_sam_line` which costs a large proportion of total runtime, the function call `startswith` can be replaced by a simple `==` to save time. Benchmarks on the entire program (rank == none):

before: `if line.startswith('@'):`: 1m39.172s
after: `if line[0] == '@':`: 1m34.688s

So this simple change saves 4.5 sec.

***

Also added `@PG` to the acceptable list of SAM headers. Some programs like Minimap2 uses this header without `@HD`.