### PR TITLE
Replace dictionary with two queues for read map

### DIFF
--- a/woltka/align.py
+++ b/woltka/align.py
@@ -42,8 +42,10 @@ def parse_align_file(fh, mapper, fmt=None, n=None):
 
     Yields
     ------
-    dict of set
-        Query-to-subject(s) map.
+    deque of str
+        Query queue.
+    deque of set of str
+        Subject(s) queue.
 
     Notes
     -----
@@ -171,12 +173,15 @@ class Plain(object):
 
         Returns
         -------
-        dict of set
-            Processed read map.
+        deque of str
+            Query queue.
+        deque of set of str
+            Subject(s) queue.
         """
-        res = dict(zip(self.qryque, self.subque))
-        self.__init__()
-        return res
+        try:
+            return self.qryque, self.subque
+        finally:
+            self.__init__()
 
 
 def infer_align_format(line):

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -11,6 +11,9 @@
 """Functions for matching reads and genes using an ordinal system.
 """
 
+from collections import defaultdict
+from operator import itemgetter
+
 
 class Ordinal(object):
     """Processor for matching reads and genes in an ordinal system.
@@ -106,36 +109,48 @@ class Ordinal(object):
 
         Returns
         -------
-        deque of str
+        iterable of str
             Query queue.
-        deque of set of str
+        iterable of set of str
             Subject(s) queue.
         """
-        res = {}
+        # preload references to class attributes
+        th = self.th
+        rids = self.rids
+        coords = self.coords
+        lenmap = self.lenmap
+
+        # master read-to-gene(s) map
+        res = defaultdict(set)
+
+        # decide matching function depending on whether prefix
+        match_func = match_read_gene_pfx if self.prefix else match_read_gene
+
         for nucl, loci in self.locmap.items():
 
             # merge and sort coordinates
             # question is to merge an unsorted list into a sorted one
             # Python's built-in "timesort" algorithm is efficient at this
             try:
-                queue = sorted(self.coords[nucl] + loci, key=lambda x: x[0])
+                queue = sorted(coords[nucl] + loci)
 
             # it's possible that no gene was annotated on the nucleotide
             except KeyError:
                 continue
 
-            # map reads to genes
-            res_ = match_read_gene(queue, self.lenmap[nucl], self.th)
+            # map reads to genes using the core algorithm
+            for read, gene in match_func(queue, lenmap[nucl], th, nucl):
 
-            # prefix
-            pref = nucl if self.prefix else None
+                # merge read-gene pairs to the master map
+                res[read].add(gene)
 
-            # merge into master read map (of current chunk)
-            add_match_to_readmap(res, res_, self.rids, pref)
+        # return read Ids (based on indices) and gene Ids
+        try:
+            return itemgetter(*res)(rids), res.values()
 
-        # free memory
-        self.clear()
-        return zip(*res.items())
+        # clean up
+        finally:
+            self.clear()
 
     def clear(self):
         self.rids = []
@@ -240,7 +255,7 @@ def whether_prefix(coords):
     return False
 
 
-def match_read_gene(queue, lens, th=0.8):
+def match_read_gene(queue, lens, th, pfx=None):
     """Associate reads with genes based on a sorted queue of coordinates.
 
     Parameters
@@ -250,16 +265,21 @@ def match_read_gene(queue, lens, th=0.8):
         (loc, is_start, is_gene, id)
     lens : dict
         Read-to-alignment length map.
-    th : float, optional
+    th : float
         Threshold for read/gene overlapping fraction.
+    pfx : str, optional
+        Placeholder for compatibility with match_read_gene_pfx
 
-    Returns
-    -------
-    dict
-        Read-to-gene(s) map.
+    Yields
+    ------
+    int
+        Read index.
+    str
+        Gene ID.
 
     See Also
     --------
+    match_read_gene_pfx
     read_gene_coords
 
     Notes
@@ -269,12 +289,12 @@ def match_read_gene(queue, lens, th=0.8):
     Only one round of traversal (O(n)) of this list is needed to accurately
     find all gene-read matches.
     """
-    match = {}  # read/gene match
     genes = {}  # current genes
     reads = {}  # current reads
 
-    # cache function reference
-    add_to_match = match.setdefault
+    # cache method references
+    reads_items = reads.items
+    genes_items = genes.items
 
     # walk through flattened queue of reads and genes
     for loc, is_start, is_gene, id_ in queue:
@@ -288,11 +308,11 @@ def match_read_gene(queue, lens, th=0.8):
             else:
 
                 # check current reads
-                for rid, rloc in reads.items():
+                for rid, rloc in reads_items():
 
                     # add to match if read/gene overlap is long enough
                     if loc - max(genes[id_], rloc) + 1 >= lens[rid] * th:
-                        add_to_match(rid, set()).add(id_)
+                        yield rid, id_
 
                 # remove it from current genes
                 del(genes[id_])
@@ -302,27 +322,59 @@ def match_read_gene(queue, lens, th=0.8):
             if is_start:
                 reads[id_] = loc
             else:
-                for gid, gloc in genes.items():
+                for gid, gloc in genes_items():
                     if loc - max(reads[id_], gloc) + 1 >= lens[id_] * th:
-                        add_to_match(id_, set()).add(gid)
+                        yield id_, gid
                 del(reads[id_])
-    return match
 
 
-def add_match_to_readmap(rmap, match, rids, nucl=None):
-    """Merge current read-gene matches to master read map.
+def match_read_gene_pfx(queue, lens, th, pfx):
+    """Associate reads with genes based on a sorted queue of coordinates.
+
     Parameters
     ----------
-    rmap : dict
-        Master read map.
-    match : dict
-        Current read map.
-    rids : list
-        Read ID list.
-    nucl : str, optional
-        Prefix nucleotide ID to gene IDs.
+    queue : list of tuple
+        Sorted list of elements.
+        (loc, is_start, is_gene, id)
+    lens : dict
+        Read-to-alignment length map.
+    th : float
+        Threshold for read/gene overlapping fraction.
+    pfx : str
+        Prefix to append to gene IDs.
+
+    Yields
+    ------
+    int
+        Read index.
+    str
+        Gene ID.
+
+    See Also
+    --------
+    match_read_gene
+
+    Notes
+    -----
+    This function is identical to `match_read_gene`, except for that it adds a
+    prefix (usually a nucleotide ID) to each gene ID.
     """
-    for idx, genes in match.items():
-        if nucl:
-            genes = {f'{nucl}_{x}' for x in genes}
-        rmap.setdefault(rids[idx], set()).update(genes)
+    genes, reads = {}, {}
+    reads_items, genes_items = reads.items, genes.items
+    for loc, is_start, is_gene, id_ in queue:
+        if is_gene:
+            if is_start:
+                genes[id_] = loc
+            else:
+                for rid, rloc in reads_items():
+                    if loc - max(genes[id_], rloc) + 1 >= lens[rid] * th:
+                        yield rid, f'{pfx}_{id_}'
+                del(genes[id_])
+        else:
+            if is_start:
+                reads[id_] = loc
+            else:
+                for gid, gloc in genes_items():
+                    if loc - max(reads[id_], gloc) + 1 >= lens[id_] * th:
+                        yield id_, f'{pfx}_{gid}'
+                del(reads[id_])

--- a/woltka/tests/test_classify.py
+++ b/woltka/tests/test_classify.py
@@ -166,43 +166,54 @@ class ClassifyTests(TestCase):
         self.assertIsNone(obs)
 
     def test_strip_index(self):
-        dic = {'R1': {'G1_1', 'G1_2', 'G2_3', 'G3'},
-               'R2': {'G1_1', 'G1.3', 'G4_5', 'G4_x'}}
-        strip_index(dic)
-        self.assertDictEqual(dic, {
-            'R1': {'G1', 'G2', 'G3'},
-            'R2': {'G1', 'G1.3', 'G4', 'G4'}})
-        dic = {'R1': {'G1.1', 'G1.2', 'G2'},
-               'R2': {'G1.1', 'G1.3', 'G3_x'}}
-        strip_index(dic, '.')
-        self.assertDictEqual(dic, {
-            'R1': {'G1', 'G2'}, 'R2': {'G1', 'G3_x'}})
+        subs = [{'G1_1', 'G1_2', 'G2_3', 'G3'},
+                {'G1_1', 'G1.3', 'G4_5', 'G4_x'}]
+        obs = strip_index(subs)
+        exp = [{'G1', 'G2', 'G3'},
+               {'G1', 'G1.3', 'G4', 'G4'}]
+        self.assertListEqual(list(obs), exp)
+        subs = [{'G1.1', 'G1.2', 'G2'},
+                {'G1.1', 'G1.3', 'G3_x'}]
+        obs = strip_index(subs, sep='.')
+        exp = [{'G1', 'G2'},
+               {'G1', 'G3_x'}]
+        self.assertListEqual(list(obs), exp)
 
     def test_demultiplex(self):
         # simple case
-        dic = {'S1_R1': 5,
-               'S1_R2': 12,
-               'S1_R3': 3,
-               'S2_R1': 10,
-               'S2_R2': 8,
-               'S2_R4': 7,
-               'S3_R2': 15,
-               'S3_R3': 1,
-               'S3_R4': 5}
-        obs = demultiplex(dic)
-        exp = {'S1': {'R1': 5, 'R2': 12, 'R3': 3},
-               'S2': {'R1': 10, 'R2': 8, 'R4': 7},
-               'S3': {'R2': 15, 'R3': 1, 'R4': 5}}
-        self.assertDictEqual(obs, exp)
+        rmap = [('S1_R1', 5),
+                ('S1_R2', 12),
+                ('S1_R3', 3),
+                ('S2_R1', 10),
+                ('S2_R2', 8),
+                ('S2_R4', 7),
+                ('S3_R2', 15),
+                ('S3_R3', 1),
+                ('S3_R4', 5)]
+        obs = demultiplex(*zip(*rmap))
+        exp = {'S1': [('R1',  5),
+                      ('R2', 12),
+                      ('R3',  3)],
+               'S2': [('R1', 10),
+                      ('R2',  8),
+                      ('R4',  7)],
+               'S3': [('R2', 15),
+                      ('R3',  1),
+                      ('R4',  5)]}
+        self.assertEqual(obs.keys(), exp.keys())
+        for s in obs:
+            self.assertListEqual(list(map(tuple, obs[s])), list(zip(*exp[s])))
 
         # change separator, no result
-        obs = demultiplex(dic, sep='.')
-        self.assertDictEqual(obs, {'': dic})
+        obs = demultiplex(*zip(*rmap), sep='.')
+        self.assertEqual(obs.keys(), {''})
+        self.assertListEqual(list(map(tuple, obs[''])), list(zip(*rmap)))
 
         # enforce sample Ids
-        obs = demultiplex(dic, samples=['S1', 'S2', 'SX'])
-        exp = {x: exp[x] for x in ['S1', 'S2']}
-        self.assertDictEqual(obs, exp)
+        obs = demultiplex(*zip(*rmap), samples=['S1', 'S2', 'SX'])
+        self.assertEqual(obs.keys(), {'S1', 'S2'})
+        for s in ('S1', 'S2'):
+            self.assertListEqual(list(map(tuple, obs[s])), list(zip(*exp[s])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A major test of data structure change: The query-to-subject(s) map. Previously it was a dictionary of sets. Now it is two queues with equal length for queries and subject sets. Notes:

1. An alternative data structure is a queue of tuple of query/subject(s) pairs. Its performance is moderately lower than the current one. However it may be more readable.
1. `deque` is used for the `Plain` mapper, because it is slightly faster than native `list` according to my tests. However `list` may be more readable and makes unit test easier.

Significant performance improvement was observed:

`align.parse_align_file`: 319 ms ± 3.45 ms => 298 ms ± 1.48 ms (~6.5% improvement)
`workflow.classify`: 370 ms ± 4.3 ms => 359 ms ± 3.2 ms