### PR TITLE
Added cache for cigar string parsing

### DIFF
--- a/woltka/align.py
+++ b/woltka/align.py
@@ -24,6 +24,7 @@ A parser function returns a tuple of:
 """
 
 from collections import deque
+from functools import lru_cache
 
 
 def plain_mapper(fh, fmt=None, n=1000000):
@@ -298,6 +299,7 @@ def parse_sam_line(line):
     return qname, rname, None, length, pos, pos + offset - 1
 
 
+@lru_cache(maxsize=128)
 def cigar_to_lens(cigar):
     """Extract lengths from a CIGAR string.
 


### PR DESCRIPTION
Significantly improved performance. Benchmark of CIGAR parsing alone on a real SHOGUN / Bowtie2 alignment file, which has 1342487 alignments:

- Before: 714 ms ± 18.4 ms per loop
- After: 85.3 ms ± 1.51 ms per loop

Benchmark of the entire `plain_mapper` function on 100000 SAM alignments:

- Before: 262 ms ± 2.85 ms per loop
- After: 214 ms ± 1.26 ms per loop

Also see issue #38 