### PR TITLE
Used frozenset

### DIFF
--- a/woltka/align.py
+++ b/woltka/align.py
@@ -78,7 +78,7 @@ def plain_mapper(fh, fmt=None, n=1000000):
 
         # add subject to subject set of the same query Id
         if query == this:
-            subque[-1].add(subject)
+            subque[-1].append(subject)
 
         # when query Id changes,
         else:
@@ -101,7 +101,7 @@ def plain_mapper(fh, fmt=None, n=1000000):
 
             # create new query and subject set pair
             qry_append(query)
-            sub_append({subject})
+            sub_append([subject])
 
             # update current query Id
             this = query

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -12,8 +12,6 @@
 hierarchical classification system.
 """
 
-from collections import deque
-
 from .util import count_list
 from .tree import find_rank, find_lca
 
@@ -187,48 +185,3 @@ def majority(taxa, th=0.8):
     for taxon, n in sorted(count_list(taxa).items(), key=lambda x: x[1],
                            reverse=True):
         return taxon if n >= len(taxa) * th else None
-
-
-def strip_index(subque, sep='_'):
-    """Remove "underscore index" suffixes from subject IDs.
-
-    Parameters
-    ----------
-    subque : deque
-        Subject(s) queue to manipulate.
-    sep : str, optional
-        Separator between subject ID and index.
-    """
-    return deque(set(x.rsplit(sep, 1)[0] for x in subs) for subs in subque)
-
-
-def demultiplex(qryque, subque, samples=None, sep='_'):
-    """Demultiplex a read-to-subject(s) map.
-
-    Parameters
-    ----------
-    qryque : deque
-        Query queue to demultiplex.
-    subque : deque
-        Corresponding subject(s) queue.
-    samples : iterable of str, optional
-        Sample IDs to keep.
-    sep : str, optional
-        Separator between sample ID and read ID.
-
-    Returns
-    -------
-    dict of (deque, deque)
-        Per-sample read-to-subject(s) maps.
-    """
-    if samples:
-        samset = set(samples)
-    qryques, subques = {}, {}
-    qry_add, sub_add = qryques.setdefault, subques.setdefault
-    for query, subjects in zip(qryque, subque):
-        left, _, right = query.partition(sep)
-        sample, read = right and left, right or left
-        if not samples or sample in samset:
-            qry_add(sample, deque()).append(read)
-            sub_add(sample, deque()).append(subjects)
-    return {x: (qryques[x], subques[x]) for x in qryques}

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -45,47 +45,47 @@ class AlignTests(TestCase):
             'R5	G5')))
         obs = plain_mapper(aln)
         exp = ((['R1', 'R2', 'R3', 'R4', 'R5'],
-                [{'G1'}, {'G1', 'G2'}, {'G1', 'G3'}, {'G4'}, {'G5'}]),)
+                [['G1'], ['G1', 'G2'], ['G1', 'G3'], ['G4'], ['G5']]),)
         self.assertTupleEqual(_res2lst(obs), exp)
 
         # chunk of 1
         aln.seek(0)
         obs = plain_mapper(aln, n=1)
-        exp = ((['R1'], [{'G1'}]),
-               (['R2'], [{'G1', 'G2'}]),
-               (['R3'], [{'G1', 'G3'}]),
-               (['R4'], [{'G4'}]),
-               (['R5'], [{'G5'}]))
+        exp = ((['R1'], [['G1']]),
+               (['R2'], [['G1', 'G2']]),
+               (['R3'], [['G1', 'G3']]),
+               (['R4'], [['G4']]),
+               (['R5'], [['G5']]))
         self.assertTupleEqual(_res2lst(obs), exp)
 
         # chunk of 2
         aln.seek(0)
         obs = plain_mapper(aln, n=2)
-        exp = ((['R1', 'R2'], [{'G1'}, {'G1', 'G2'}]),
-               (['R3'], [{'G1', 'G3'}]),
-               (['R4', 'R5'], [{'G4'}, {'G5'}]))
+        exp = ((['R1', 'R2'], [['G1'], ['G1', 'G2']]),
+               (['R3'], [['G1', 'G3']]),
+               (['R4', 'R5'], [['G4'], ['G5']]))
         self.assertTupleEqual(_res2lst(obs), exp)
 
         # chunk of 3
         aln.seek(0)
         obs = plain_mapper(aln, n=3)
-        exp = ((['R1', 'R2'], [{'G1'}, {'G1', 'G2'}]),
-               (['R3', 'R4'], [{'G1', 'G3'}, {'G4'}]),
-               (['R5'], [{'G5'}]))
+        exp = ((['R1', 'R2'], [['G1'], ['G1', 'G2']]),
+               (['R3', 'R4'], [['G1', 'G3'], ['G4']]),
+               (['R5'], [['G5']]))
         self.assertTupleEqual(_res2lst(obs), exp)
 
         # chunk of 4
         aln.seek(0)
         obs = plain_mapper(aln, n=4)
-        exp = ((['R1', 'R2', 'R3'], [{'G1'}, {'G1', 'G2'}, {'G1', 'G3'}]),
-               (['R4', 'R5'], [{'G4'}, {'G5'}]))
+        exp = ((['R1', 'R2', 'R3'], [['G1'], ['G1', 'G2'], ['G1', 'G3']]),
+               (['R4', 'R5'], [['G4'], ['G5']]))
         self.assertTupleEqual(_res2lst(obs), exp)
 
         # chunk of 5
         aln.seek(0)
         obs = plain_mapper(aln, n=5)
-        exp = ((['R1', 'R2', 'R3'], [{'G1'}, {'G1', 'G2'}, {'G1', 'G3'}]),
-               (['R4', 'R5'], [{'G4'}, {'G5'}]))
+        exp = ((['R1', 'R2', 'R3'], [['G1'], ['G1', 'G2'], ['G1', 'G3']]),
+               (['R4', 'R5'], [['G4'], ['G5']]))
         self.assertTupleEqual(_res2lst(obs), exp)
 
         # format is given

--- a/woltka/tests/test_classify.py
+++ b/woltka/tests/test_classify.py
@@ -14,8 +14,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 from woltka.classify import (
-    assign_none, assign_free, assign_rank, count, count_strata, majority,
-    strip_index, demultiplex)
+    assign_none, assign_free, assign_rank, count, count_strata, majority)
 
 
 class ClassifyTests(TestCase):
@@ -164,62 +163,6 @@ class ClassifyTests(TestCase):
         self.assertIsNone(obs)
         obs = majority([])
         self.assertIsNone(obs)
-
-    def test_strip_index(self):
-        subs = [{'G1_1', 'G1_2', 'G2_3', 'G3'},
-                {'G1_1', 'G1.3', 'G4_5', 'G4_x'}]
-        obs = strip_index(subs)
-        exp = [{'G1', 'G2', 'G3'},
-               {'G1', 'G1.3', 'G4', 'G4'}]
-        self.assertListEqual(list(obs), exp)
-
-        subs = [{'NC_123456.1_300', 'ABCD000001.20_101'}]
-        obs = strip_index(subs)
-        exp = [{'NC_123456.1', 'ABCD000001.20'}]
-        self.assertListEqual(list(obs), exp)
-
-        subs = [{'G1.1', 'G1.2', 'G2'},
-                {'G1.1', 'G1.3', 'G3_x'}]
-        obs = strip_index(subs, sep='.')
-        exp = [{'G1', 'G2'},
-               {'G1', 'G3_x'}]
-        self.assertListEqual(list(obs), exp)
-
-    def test_demultiplex(self):
-        # simple case
-        rmap = [('S1_R1', 5),
-                ('S1_R2', 12),
-                ('S1_R3', 3),
-                ('S2_R1', 10),
-                ('S2_R2', 8),
-                ('S2_R4', 7),
-                ('S3_R2', 15),
-                ('S3_R3', 1),
-                ('S3_R4', 5)]
-        obs = demultiplex(*zip(*rmap))
-        exp = {'S1': [('R1',  5),
-                      ('R2', 12),
-                      ('R3',  3)],
-               'S2': [('R1', 10),
-                      ('R2',  8),
-                      ('R4',  7)],
-               'S3': [('R2', 15),
-                      ('R3',  1),
-                      ('R4',  5)]}
-        self.assertEqual(obs.keys(), exp.keys())
-        for s in obs:
-            self.assertListEqual(list(map(tuple, obs[s])), list(zip(*exp[s])))
-
-        # change separator, no result
-        obs = demultiplex(*zip(*rmap), sep='.')
-        self.assertEqual(obs.keys(), {''})
-        self.assertListEqual(list(map(tuple, obs[''])), list(zip(*rmap)))
-
-        # enforce sample Ids
-        obs = demultiplex(*zip(*rmap), samples=['S1', 'S2', 'SX'])
-        self.assertEqual(obs.keys(), {'S1', 'S2'})
-        for s in ('S1', 'S2'):
-            self.assertListEqual(list(map(tuple, obs[s])), list(zip(*exp[s])))
 
 
 if __name__ == '__main__':

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -9,7 +9,6 @@
 # ----------------------------------------------------------------------------
 
 from unittest import TestCase, main
-from collections import deque
 from os import remove
 from os.path import join, dirname, realpath
 from shutil import rmtree
@@ -22,7 +21,7 @@ from pandas.testing import assert_frame_equal
 
 from woltka.workflow import (
     workflow, classify, parse_samples, parse_strata, build_mapper,
-    prepare_ranks, build_hierarchy, reshape_readmap, assign_readmap,
+    prepare_ranks, build_hierarchy, assign_readmap, strip_index, demultiplex,
     write_profiles)
 
 
@@ -363,38 +362,66 @@ class WorkflowTests(TestCase):
         self.assertDictEqual(obs[1], {'Bac': 'map', 'Arc': 'map'})
         remove(fp)
 
-    def test_reshape_readmap(self):
-        # doing nothing
-        qryq = ['R1', 'R2', 'R3']
-        subq = [{'G1'}, {'G2'}, {'G3', 'G4'}]
-        obs = reshape_readmap(qryq, subq)
-        self.assertDictEqual(obs, {None: (qryq, subq)})
+    def test_strip_index(self):
+        subs = [{'G1_1', 'G1_2', 'G2_3', 'G3'},
+                {'G1_1', 'G1.3', 'G4_5', 'G4_x'}]
+        obs = strip_index(subs)
+        exp = [{'G1', 'G2', 'G3'},
+               {'G1', 'G1.3', 'G4', 'G4'}]
+        self.assertListEqual(list(obs), exp)
 
-        # with filename
-        obs = reshape_readmap(qryq, subq, files={'fname': 'S1'}, fp='fname')
-        self.assertDictEqual(obs, {'S1': (qryq, subq)})
+        subs = [{'NC_123456.1_300', 'ABCD000001.20_101'}]
+        obs = strip_index(subs)
+        exp = [{'NC_123456.1', 'ABCD000001.20'}]
+        self.assertListEqual(list(obs), exp)
 
-        # remove index
-        subq_ = [{'G1'}, {'G2_1'}, {'G3_1', 'G4_2'}]
-        obs = reshape_readmap(qryq, subq_, deidx=True)
-        self.assertDictEqual(obs, {None: (qryq, deque(subq))})
+        subs = [{'G1.1', 'G1.2', 'G2'},
+                {'G1.1', 'G1.3', 'G3_x'}]
+        obs = strip_index(subs, sep='.')
+        exp = [{'G1', 'G2'},
+               {'G1', 'G3_x'}]
+        self.assertListEqual(list(obs), exp)
 
-        # demultiplex
-        qryq_ = ['S1_R1', 'S1_R2', 'S2_R3']
-        obs = reshape_readmap(qryq_, subq, demux=True)
-        self.assertDictEqual(obs, {
-            'S1': (deque(['R1', 'R2']), deque([{'G1'}, {'G2'}])),
-            'S2': (deque(['R3']), deque([{'G3', 'G4'}]))})
+    def test_demultiplex(self):
+        # simple case
+        rmap = [('S1_R1', 5),
+                ('S1_R2', 12),
+                ('S1_R3', 3),
+                ('S2_R1', 10),
+                ('S2_R2', 8),
+                ('S2_R4', 7),
+                ('S3_R2', 15),
+                ('S3_R3', 1),
+                ('S3_R4', 5)]
+        obs = demultiplex(*zip(*rmap))
+        exp = {'S1': [('R1',  5),
+                      ('R2', 12),
+                      ('R3',  3)],
+               'S2': [('R1', 10),
+                      ('R2',  8),
+                      ('R4',  7)],
+               'S3': [('R2', 15),
+                      ('R3',  1),
+                      ('R4',  5)]}
+        self.assertEqual(obs.keys(), exp.keys())
+        for s in obs:
+            self.assertListEqual(list(map(tuple, obs[s])), list(zip(*exp[s])))
 
-        # demultiplex to given sample Ids
-        obs = reshape_readmap(qryq_, subq, demux=True, samples=['S1'])
-        self.assertDictEqual(obs, {
-            'S1': (deque(['R1', 'R2']), deque([{'G1'}, {'G2'}]))})
+        # change separator, no result
+        obs = demultiplex(*zip(*rmap), sep='.')
+        self.assertEqual(obs.keys(), {''})
+        self.assertListEqual(list(map(tuple, obs[''])), list(zip(*rmap)))
+
+        # enforce sample Ids
+        obs = demultiplex(*zip(*rmap), samples=['S1', 'S2', 'SX'])
+        self.assertEqual(obs.keys(), {'S1', 'S2'})
+        for s in ('S1', 'S2'):
+            self.assertListEqual(list(map(tuple, obs[s])), list(zip(*exp[s])))
 
     def test_assign_readmap(self):
         # simple gotu assignment
         qryq = ['R1', 'R2', 'R3']
-        subq = [{'G1'}, {'G1', 'G2'}, {'G2', 'G3'}]
+        subq = [frozenset(x) for x in [{'G1'}, {'G1', 'G2'}, {'G2', 'G3'}]]
         data = {'none': {}}
         assign_readmap(qryq, subq, data, 'none', 'S1')
         self.assertDictEqual(data['none']['S1'], {'G1': 2, 'G2': 1})

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -28,8 +28,7 @@ from .file import (
     write_readmap, write_table)
 from .align import plain_mapper
 from .classify import (
-    assign_none, assign_free, assign_rank, count, count_strata, strip_index,
-    demultiplex)
+    assign_none, assign_free, assign_rank, count, count_strata)
 from .tree import (
     read_names, read_nodes, read_lineage, read_newick, read_rank_table,
     fill_root)
@@ -201,6 +200,12 @@ def classify(mapper:  object,
     -------
     dict of dict
         Per-rank profiles generated from classification.
+
+    Notes
+    -----
+    Subject(s) of each query are converted into a frozenset. This is because
+    frozenset is hashable, a property necessary for subsequent assignment
+    result caching.
     """
     data = {x: {} for x in ranks}
 
@@ -222,19 +227,22 @@ def classify(mapper:  object,
         with openzip(fp) as fh:
 
             # parse alignment file by chunk
-            # for qryque, subque in parse_align_file(fh, mapper, fmt, lines):
             for qryque, subque in mapper(fh, fmt=fmt, n=lines):
 
                 # show progress
                 click.echo('.', nl=False)
                 n += len(qryque)
 
-                # reshape read map
-                rmap = reshape_readmap(
-                    qryque, subque, deidx, demux, samples, files, fp)
+                # (optionally) strip indices and freeze sets
+                subque = deque(strip_index(subque) if deidx else map(
+                    frozenset, subque))
+
+                # (optionally) demultiplex and generate per-sample maps
+                rmaps = demultiplex(qryque, subque, samples) if demux else {
+                    files[fp] if files else None: (qryque, subque)}
 
                 # assign reads at each rank
-                for sample, (qryque, subque) in rmap.items():
+                for sample, (qryque, subque) in rmaps.items():
 
                     # read strata of current sample into cache
                     if stratmap and sample != csample:
@@ -575,52 +583,58 @@ def build_hierarchy(names_fps:    list = [],
     return tree, rankdic, namedic, root
 
 
-def reshape_readmap(qryque: deque,
-                    subque: deque,
-                    deidx:   bool = None,
-                    demux:   bool = None,
-                    samples: list = None,
-                    files:   dict = None,
-                    fp:       str = None) -> dict:
-    """Reshape a read map.
+def strip_index(subque, sep='_'):
+    """Remove "underscore index" suffixes from subject IDs.
+
+    Parameters
+    ----------
+    subque : iterable
+        Subject(s) queue to manipulate.
+    sep : str, optional
+        Separator between subject ID and index.
+
+    Returns
+    -------
+    generator of frozenset
+        Processed subject(s) queue.
+    """
+    return (frozenset(x.rsplit(sep, 1)[0] for x in subs) for subs in subque)
+
+
+def demultiplex(qryque, subque, samples=None, sep='_'):
+    """Demultiplex a read-to-subject(s) map.
 
     Parameters
     ----------
     qryque : deque
-        Query queue to manipulate.
+        Query queue to demultiplex.
     subque : deque
-        Subject(s) queue to manipulate.
-    deidx : bool, optional
-        Strip suffixes from subject IDs.
-    demux : bool, optional
-        Whether perform demultiplexing.
-    samples : list of str, optional
-        Sample ID list to include.
-    files : list or dict
-        Map of filepaths to sample IDs.
-    fp : str
-        Path to current alignment file.
+        Corresponding subject(s) queue.
+    samples : iterable of str, optional
+        Sample IDs to keep.
+    sep : str, optional
+        Separator between sample ID and read ID.
 
     Returns
     -------
-    dict
-        Reshaped read map.
+    dict of (deque, deque)
+        Per-sample read-to-subject(s) maps.
     """
-    # strip indices from subjects
-    if deidx:
-        subque = strip_index(subque)
+    if samples:
+        samset = set(samples)
+    qryques, subques = {}, {}
+    qry_add, sub_add = qryques.setdefault, subques.setdefault
+    for query, subjects in zip(qryque, subque):
+        left, _, right = query.partition(sep)
+        sample, read = right and left, right or left
+        if not samples or sample in samset:
+            qry_add(sample, deque()).append(read)
+            sub_add(sample, deque()).append(subjects)
+    return {x: (qryques[x], subques[x]) for x in qryques}
 
-    # demultiplex into multiple samples
-    if demux:
-        return demultiplex(qryque, subque, samples)
 
-    # sample Id from filename
-    else:
-        return {files[fp] if files else None: (qryque, subque)}
-
-
-def assign_readmap(qryque:  deque,
-                   subque:  deque,
+def assign_readmap(qryque:   list,
+                   subque:   list,
                    data:     dict,
                    rank:      str,
                    sample:    str,
@@ -640,9 +654,9 @@ def assign_readmap(qryque:  deque,
 
     Parameters
     ----------
-    qryque : deque
+    qryque : iterable of str
         Query queue to assign.
-    subque : deque
+    subque : iterable of frozenset
         Subject(s) queue for assignment.
     data : dict
         Master data structure.
@@ -692,7 +706,7 @@ def assign_readmap(qryque:  deque,
     asgmt = {}
     for query, subjects in zip(qryque, subque):
         # res = assigner(subjects, *args)
-        res = assigner(frozenset(subjects))
+        res = assigner(subjects)
         if res is not None:
             asgmt[query] = res
 

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -598,7 +598,8 @@ def strip_index(subque, sep='_'):
     generator of frozenset
         Processed subject(s) queue.
     """
-    return (frozenset(x.rsplit(sep, 1)[0] for x in subs) for subs in subque)
+    return map(frozenset, map(partial(
+        map, lambda x: x.rsplit(sep, 1)[0]), subque))
 
 
 def demultiplex(qryque, subque, samples=None, sep='_'):


### PR DESCRIPTION
Subject(s) of each query are converted into a **frozenset**. This is because frozensets are _hashable_, a property necessary for subsequent assignment result caching.

Memory footprint increases because of the copy of this large data structure, but it is trivial compared with the overall memory consumption of the program. It is an option to return a generator instead of the actual data, which will be faster and less memory-consuming. However, the obstacle is that one or multiple ranks may be specified by the user, and this data structure needs to be re-used in the latter case. Therefore, a generator won't work.

This change further allows the plain mapper to yield queues of **lists** instead of **sets**. Moderate performance improvement was observed along with this change:

- 214 ms ± 1.5 ms => 207 ms ± 1.52 ms