### PR TITLE
Optimizing classification functions

### DIFF
--- a/woltka/biom.py
+++ b/woltka/biom.py
@@ -14,7 +14,7 @@
 import numpy as np
 import biom
 from .util import allkeys
-from .tree import get_lineage_gg
+from .tree import lineage_str
 from .__init__ import __name__, __version__
 
 
@@ -74,7 +74,7 @@ def profile_to_biom(profile, samples=None, tree=None, rankdic=None,
             meta_['Rank'] = rankdic[feature] if feature in rankdic else None
         # get lineage string
         if tree:
-            meta_['Lineage'] = get_lineage_gg(
+            meta_['Lineage'] = lineage_str(
                 feature, tree, namedic if name_as_id else None) or None
         if meta_:
             metadata.append(meta_)

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -12,6 +12,8 @@
 hierarchical classification system.
 """
 
+from operator import itemgetter
+
 from .util import count_list
 from .tree import find_rank, find_lca
 
@@ -182,6 +184,6 @@ def majority(taxa, th=0.8):
     str or None
         Selected taxon.
     """
-    for taxon, n in sorted(count_list(taxa).items(), key=lambda x: x[1],
+    for taxon, n in sorted(count_list(taxa).items(), key=itemgetter(1),
                            reverse=True):
         return taxon if n >= len(taxa) * th else None

--- a/woltka/file.py
+++ b/woltka/file.py
@@ -18,7 +18,7 @@ import bz2
 import lzma
 
 from .util import allkeys, feat_n_cnt
-from .tree import get_lineage_gg
+from .tree import lineage_str
 
 
 ZIPDIC = {'.gz': gzip, '.gzip': gzip,
@@ -412,7 +412,7 @@ def write_table(fh, data, samples=None, tree=None, rankdic=None, namedic=None,
             row.append(rankdic[feature] if feature in rankdic else '')
         # fill lineage column
         if tree:
-            row.append(get_lineage_gg(
+            row.append(lineage_str(
                 feature, tree, namedic if name_as_id else None))
         # print row
         print('\t'.join(row), file=fh)

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -215,7 +215,7 @@ def read_gene_coords(fh, sort=False):
 
     See Also
     --------
-    map_read_gene
+    match_read_gene
 
     Notes
     -----
@@ -253,7 +253,7 @@ def read_gene_coords(fh, sort=False):
     # sort gene coordinates per nucleotide
     if sort:
         for nucl, queue in res.items():
-            res[nucl] = sorted(queue, key=lambda x: x[0])
+            res[nucl] = sorted(queue, key=itemgetter(0))
 
     return res
 
@@ -350,7 +350,7 @@ def match_read_gene(queue, lens, th, pfx=None):
                 # check current reads
                 for rid, rloc in reads_items():
 
-                    # add to match if read/gene overlap is long enough
+                    # is a match if read/gene overlap is long enough
                     if loc - max(genes[id_], rloc) + 1 >= lens[rid] * th:
                         yield rid, id_
 

--- a/woltka/tests/test_tree.py
+++ b/woltka/tests/test_tree.py
@@ -15,7 +15,7 @@ from tempfile import mkdtemp
 
 from woltka.tree import (
     read_names, read_nodes, read_lineage, read_newick, read_rank_table,
-    fill_root, get_lineage, get_lineage_gg, find_rank, find_lca)
+    fill_root, get_lineage, lineage_str, find_rank, find_lca)
 
 
 # A small test taxon set containing 15 proteobacterial species
@@ -423,22 +423,22 @@ class TreeTests(TestCase):
         exp = ['1', '131567', '2', '1224', '1236', '72274', '135621', '286']
         self.assertListEqual(obs, exp)
 
-    def test_get_lineage_gg(self):
+    def test_lineage_str(self):
         tree = self.proteo['tree']
-        obs = get_lineage_gg('561', tree)
+        obs = lineage_str('561', tree)
         self.assertEqual(obs, '1236;91347;543')
-        obs = get_lineage_gg('561', tree, include_root=True)
+        obs = lineage_str('561', tree, include_root=True)
         self.assertEqual(obs, '1224;1236;91347;543')
-        obs = get_lineage_gg('561', tree, include_self=True)
+        obs = lineage_str('561', tree, include_self=True)
         self.assertEqual(obs, '1236;91347;543;561')
-        obs = get_lineage_gg('561', tree, self.proteo['names'])
+        obs = lineage_str('561', tree, self.proteo['names'])
         exp = 'Gammaproteobacteria;Enterobacterales;Enterobacteriaceae'
         self.assertEqual(obs, exp)
-        obs = get_lineage_gg('1224', tree)
+        obs = lineage_str('1224', tree)
         self.assertEqual(obs, '')
-        obs = get_lineage_gg('1236', tree)
+        obs = lineage_str('1236', tree)
         self.assertEqual(obs, '')
-        obs = get_lineage_gg('0000', tree)
+        obs = lineage_str('0000', tree)
         self.assertEqual(obs, '')
 
     def test_fill_root(self):
@@ -536,6 +536,12 @@ class TreeTests(TestCase):
         self.assertEqual(find_lca(['1'], tree), '1')
         self.assertIsNone(find_lca(['1234'], tree))
         self.assertIsNone(find_lca(['1234', '1'], tree))
+        self.assertIsNone(find_lca(['1', '2', '3'], tree))
+        self.assertEqual(find_lca(['1', '1'], tree), '1')
+
+        # broken tree, only for unit test coverage
+        tree = {'1': '1', '2': '2'}
+        self.assertEqual(find_lca(['1', '2'], tree), '1')
 
         # proteo tree
         # Escherichia, Enterobacter => Enterobacteriaceae

--- a/woltka/tree.py
+++ b/woltka/tree.py
@@ -469,25 +469,25 @@ def find_rank(taxon, rank, tree, rankdic):
 
     Returns
     -------
-    str
-        Ancestral taxon if found.
+    str or None
+        Ancestral taxon at given rank, or None if not found.
     """
     # if taxon is not in tree, return None
     try:
         parent = tree[taxon]
     except KeyError:
-        return None
+        return
+
+    # cache method reference
+    get_rank = rankdic.get
 
     # move up hierarchy until reaching given rank
     this = taxon
     while True:
 
         # check rank of current taxon
-        try:
-            if rankdic[this] == rank:
-                return this
-        except KeyError:
-            pass
+        if get_rank(this) == rank:
+            return this
 
         # stop when reaching root
         if parent == this:

--- a/woltka/tree.py
+++ b/woltka/tree.py
@@ -527,15 +527,15 @@ def find_lca(taxa, tree):
     Combine LCA and majority rule, which is not trivial and requires careful
     reasoning and algorithm design.
     """
-    taxa_ = list(taxa)
+    itaxa = iter(taxa)
 
     # get lineage of first taxon
-    lineage = get_lineage(taxa_[0], tree)
+    lineage = get_lineage(next(itaxa), tree)
     if lineage is None:
         return
 
     # compare with remaining taxa
-    for taxon in taxa_[1:]:
+    for taxon in itaxa:
         try:
             parent = tree[taxon]
         except KeyError:
@@ -553,7 +553,6 @@ def find_lca(taxa, tree):
                     break
                 this = parent
                 parent = tree[this]
-                continue
 
             # trim shared lineage
             else:

--- a/woltka/tree.py
+++ b/woltka/tree.py
@@ -429,8 +429,8 @@ def get_lineage(taxon, tree):
     return lineage[::-1]
 
 
-def get_lineage_gg(taxon, tree, namedic=None, include_self=False,
-                   include_root=False):
+def lineage_str(taxon, tree, namedic=None, include_self=False,
+                include_root=False):
     """Generate a Greengenes-style lineage string of a taxon.
 
     Parameters
@@ -442,7 +442,7 @@ def get_lineage_gg(taxon, tree, namedic=None, include_self=False,
     namedic : dict, optional
         Taxon name dictionary.
     include_self : bool, optional
-        Include current taxon.
+        Include self.
     include_root : bool, optional
         Include root.
 

--- a/woltka/tree.py
+++ b/woltka/tree.py
@@ -406,18 +406,27 @@ def get_lineage(taxon, tree):
     except KeyError:
         return None
 
-    # move up classification hierarchy till root
+    # initiate lineage and cache method reference
     lineage = [taxon]
+    add_taxon = lineage.append
+
+    # move up classification hierarchy till root
     this = taxon
     while True:
-        lineage.append(parent)
-        this = parent
-        parent = tree[this]
+
+        # stop when reaching root
         if parent == this:
             break
 
-    # reverse lineage so that it's high-to-low
-    return list(reversed(lineage))
+        # add current level to lineage
+        add_taxon(parent)
+
+        # move up to parent
+        this = parent
+        parent = tree[this]
+
+    # make lineage high-to-low
+    return lineage[::-1]
 
 
 def get_lineage_gg(taxon, tree, namedic=None, include_self=False,

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -244,15 +244,14 @@ def classify(mapper:  object,
                 # assign reads at each rank
                 for sample, (qryque, subque) in rmaps.items():
 
-                    # read strata of current sample into cache
+                    # (optionally) read strata of current sample into cache
                     if stratmap and sample != csample:
                         with openzip(stratmap[sample]) as fh:
                             kwargs['strata'] = dict(read_map(fh))
                         csample = sample
 
+                    # call assignment workflow for each rank
                     for rank in ranks:
-
-                        # call assignment workflow
                         assign_readmap(
                             qryque, subque, data, rank, sample, **kwargs)
 


### PR DESCRIPTION
Thanks to @wasade 's insightful advices in issue #50 , I started to optimize the functions `find_rank`, `get_lineage` and `find_lca` accordingly. One advice I adopted is to replace `try...except...` with `dict.get` when looping up the hierarchies. This improves the performance quite a bit (see below). By design, there is a good chance that some taxa don't have rank assignments, so the error handling could cost some time. I didn't change the first `try...except...` before loop though, because the subject should be found in the tree, otherwise it is not classifiable. But once it is in the tree, the rest of hierarchies are guaranteed to be intact, and `tree[taxon]` won't cause any error. I also applied method reference and other tricks.

Benchmarks on 100,000 Bowtie2 SAM lines against the WoL database:

`find_rank`
species level: 64.3 ms ± 343 µs => 54.5 ms ± 119 µs
genus level: 75.6 ms ± 213 µs => 67.1 ms ± 203 µs
phylum level: 115 ms ± 192 µs => 111 ms ± 1.75 ms

`get_lineage`:
170 ms ± 592 µs => 133 ms ± 308 µs

`find_lca`:
189 ms ± 809 µs => 184 ms ± 1.55 ms

The `find_lca` will be further optimized in another PR.