### PR TITLE
Used empirical chunk size line number to improve performance.

### DIFF
--- a/woltka/align.py
+++ b/woltka/align.py
@@ -27,7 +27,7 @@ from collections import deque
 from functools import lru_cache
 
 
-def plain_mapper(fh, fmt=None, n=1000000):
+def plain_mapper(fh, fmt=None, n=1000):
     """Read an alignment file in chunks and yield query-to-subject(s) maps.
 
     Parameters

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -14,14 +14,9 @@ hierarchical classification system.
 
 from operator import itemgetter
 from collections import defaultdict
-from decimal import Decimal
 
 from .util import count_list
 from .tree import find_rank, find_lca
-
-
-# decimal number one for precise normalization
-one = Decimal(1)
 
 
 def assign_none(subs, ambig=False):
@@ -128,10 +123,10 @@ def count(matches):
 
     Returns
     -------
-    defaultdict of str: Decimal
+    defaultdict of str: int
         Taxon-to-count map.
     """
-    res = defaultdict(Decimal)
+    res = defaultdict(int)
     for taxa in matches.values():
         try:
             # unique match (scalar)
@@ -139,7 +134,7 @@ def count(matches):
         except TypeError:
             # multiple matches (dict of subject : count), to be normalized by
             # total match count
-            k = one / sum(taxa.values())
+            k = 1 / sum(taxa.values())
             for taxon, n in taxa.items():
                 res[taxon] += n * k
     return res
@@ -157,15 +152,15 @@ def count_strata(matches, strata):
 
     Returns
     -------
-    defaultdict of (str, str): Decimal
+    defaultdict of (str, str): int
         Stratified (feature, taxon)-to-count map.
     """
-    res = defaultdict(Decimal)
+    res = defaultdict(int)
     for query, taxa in matches.items():
         if query in strata:
             feature = strata[query]
             if isinstance(taxa, dict):
-                k = one / sum(taxa.values())
+                k = 1 / sum(taxa.values())
                 for taxon, n in taxa.items():
                     taxon = (feature, taxon)
                     res[taxon] += n * k

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -13,9 +13,15 @@ hierarchical classification system.
 """
 
 from operator import itemgetter
+from collections import defaultdict
+from decimal import Decimal
 
 from .util import count_list
 from .tree import find_rank, find_lca
+
+
+# decimal number one for precise normalization
+one = Decimal(1)
 
 
 def assign_none(subs, ambig=False):
@@ -122,20 +128,20 @@ def count(matches):
 
     Returns
     -------
-    dict
+    defaultdict of str: Decimal
         Taxon-to-count map.
     """
-    res = {}
+    res = defaultdict(Decimal)
     for taxa in matches.values():
         try:
             # unique match (scalar)
-            res[taxa] = res.get(taxa, 0) + 1
+            res[taxa] += 1
         except TypeError:
             # multiple matches (dict of subject : count), to be normalized by
             # total match count
-            k = 1 / sum(taxa.values())
+            k = one / sum(taxa.values())
             for taxon, n in taxa.items():
-                res[taxon] = res.get(taxon, 0) + n * k
+                res[taxon] += n * k
     return res
 
 
@@ -151,21 +157,21 @@ def count_strata(matches, strata):
 
     Returns
     -------
-    dict of tuple of (str, str): int
-        Stratified (feature, taxon): count map.
+    defaultdict of (str, str): Decimal
+        Stratified (feature, taxon)-to-count map.
     """
-    res = {}
+    res = defaultdict(Decimal)
     for query, taxa in matches.items():
         if query in strata:
             feature = strata[query]
             if isinstance(taxa, dict):
-                k = 1 / sum(taxa.values())
+                k = one / sum(taxa.values())
                 for taxon, n in taxa.items():
                     taxon = (feature, taxon)
-                    res[taxon] = res.get(taxon, 0) + n * k
+                    res[taxon] += n * k
             else:
                 taxon = (feature, taxa)
-                res[taxon] = res.get(taxon, 0) + 1
+                res[taxon] += 1
     return res
 
 

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -86,7 +86,7 @@ def gotu(ctx, **kwargs):
     '--demux/--no-demux', default=None,
     help='Demultiplex alignment by first underscore in query identifier.')
 @click.option(
-    '--lines', type=click.INT, default=1000000, show_default=True,
+    '--lines', type=click.INT, default=None,
     help=('Number of lines to read from alignment file per chunk.'))
 # hierarchies
 @click.option(

--- a/woltka/tests/data/output/blastn.species.tsv
+++ b/woltka/tests/data/output/blastn.species.tsv
@@ -13,7 +13,7 @@ k__Bacteria;p__Deinococcus-Thermus;c__Deinococci;o__Deinococcales;f__Deinococcac
 k__Bacteria;p__Deinococcus-Thermus;c__Deinococci;o__Thermales;f__Thermaceae;g__Thermus;s__Thermus thermophilus	1594	0	0	0	0
 k__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus anthracis	0	0	13	0	0
 k__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus cereus	0	0	2	0	0
-k__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus thuringiensis	0	0	4	1	0
+k__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus thuringiensis	0	0	3	1	0
 k__Bacteria;p__Firmicutes;c__Bacilli;o__Lactobacillales;f__Enterococcaceae;g__Enterococcus;s__Enterococcus faecalis	10	0	0	0	0
 k__Bacteria;p__Firmicutes;c__Bacilli;o__Lactobacillales;f__Enterococcaceae;g__Enterococcus;s__Enterococcus faecium	0	0	1	54	0
 k__Bacteria;p__Firmicutes;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus;s__Lactobacillus acidophilus	0	0	22	0	0

--- a/woltka/tests/test_classify.py
+++ b/woltka/tests/test_classify.py
@@ -12,6 +12,7 @@ from unittest import TestCase, main
 from os.path import join, dirname, realpath
 from shutil import rmtree
 from tempfile import mkdtemp
+from decimal import Decimal
 
 from woltka.classify import (
     assign_none, assign_free, assign_rank, count, count_strata, majority)
@@ -113,10 +114,10 @@ class ClassifyTests(TestCase):
                    'seq2': {'a': 2, 'b': 5},
                    'seq3': {'d': 4}}
         obs = count(matches)
-        exp = {'a': 1 / 6 + 2 / 7,
-               'b': 2 / 6 + 5 / 7,
-               'c': 3 / 6,
-               'd': 4 / 4}
+        exp = {'a': Decimal(1) / 6 + Decimal(2) / 7,
+               'b': Decimal(2) / 6 + Decimal(5) / 7,
+               'c': Decimal(3) / 6,
+               'd': Decimal(4) / 4}
         for key in obs:
             self.assertAlmostEqual(obs[key], exp[key])
 

--- a/woltka/tests/test_classify.py
+++ b/woltka/tests/test_classify.py
@@ -12,7 +12,6 @@ from unittest import TestCase, main
 from os.path import join, dirname, realpath
 from shutil import rmtree
 from tempfile import mkdtemp
-from decimal import Decimal
 
 from woltka.classify import (
     assign_none, assign_free, assign_rank, count, count_strata, majority)
@@ -114,10 +113,10 @@ class ClassifyTests(TestCase):
                    'seq2': {'a': 2, 'b': 5},
                    'seq3': {'d': 4}}
         obs = count(matches)
-        exp = {'a': Decimal(1) / 6 + Decimal(2) / 7,
-               'b': Decimal(2) / 6 + Decimal(5) / 7,
-               'c': Decimal(3) / 6,
-               'd': Decimal(4) / 4}
+        exp = {'a': 1 / 6 + 2 / 7,
+               'b': 2 / 6 + 5 / 7,
+               'c': 3 / 6,
+               'd': 4 / 4}
         for key in obs:
             self.assertAlmostEqual(obs[key], exp[key])
 

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -427,13 +427,15 @@ class WorkflowTests(TestCase):
         subq = [frozenset(x) for x in [{'G1'}, {'G1', 'G2'}, {'G2', 'G3'}]]
         data = {'none': {}}
         assign_readmap(qryq, subq, data, 'none', 'S1')
-        self.assertDictEqual(data['none']['S1'], {'G1': 2, 'G2': 1})
+        self.assertDictEqual(data['none']['S1'], {
+            'G1': 1.5, 'G2': 1.0, 'G3': 0.5})
 
         # write read map
         data = {'none': {'S1': {}}}
         assign_readmap(qryq, subq, data, 'none', 'S1', rank2dir={
             'none': self.tmpdir})
-        self.assertDictEqual(data['none']['S1'], {'G1': 2, 'G2': 1})
+        self.assertDictEqual(data['none']['S1'], {
+            'G1': 1.5, 'G2': 1.0, 'G3': 0.5})
         fp = join(self.tmpdir, 'S1.txt')
         with open(fp, 'r') as f:
             obs = f.read().splitlines()
@@ -453,7 +455,7 @@ class WorkflowTests(TestCase):
         data = {'ko': {}}
         assign_readmap(qryq, subq, data, 'ko', 'S1', tree=tree,
                        rankdic=rankdic)
-        self.assertDictEqual(data['ko']['S1'], {'T1': 2})
+        self.assertDictEqual(data['ko']['S1'], {'T1': 2.5, 'T2': 0.5})
 
     def test_write_profiles(self):
         # do nothing

--- a/woltka/util.py
+++ b/woltka/util.py
@@ -104,12 +104,13 @@ def intize(dic, zero=False):
         Whether keep zero values.
     """
     todel = []
+    add_todel = todel.append
     for key, value in dic.items():
         intval = round(value)
         if intval or zero:
             dic[key] = intval
         else:
-            todel.append(key)
+            add_todel(key)
     for key in todel:
         del dic[key]
 

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -714,7 +714,7 @@ def assign_readmap(qryque:   list,
                    root:      str = None,
                    above:    bool = False,
                    major:   float = None,
-                   ambig:     str = True,
+                   ambig:    bool = True,
                    subok:    bool = None,
                    strata:   dict = None):
     """Assign query sequences in a query-to-subjects map to classification


### PR DESCRIPTION
The optimal values are 1000 for the plain mapper and 1,000,000 for the ordinal mapper.

Also moved per-chunk rounding to final rounding to increase arithmetic precision.

Plus minor tweaks.