### PR TITLE
Set subok as False by default

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -49,7 +49,7 @@ Option | Description
 `--above/--no-above` | Allow assigning to a classification unit higher than given rank. Default: auto-decision.
 `--major` | Majority-rule assignment percentage threshold. Range: [51, 99].
 `--ambig/--no-ambig` | Allow assigning one sequence to multiple classification units. Default: True.
-`--subok/--no-subok` | Can report subject IDs in classification result. Default: True.
+`--subok` | In free-rank classification, allow assigning a sequence to its direct subject, if applicable, before going up in hierarchy.
 `--deidx/--no-deidx` | Strip "underscore index" suffixes from subject IDs. Default: False.
 
 ### Gene matching

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -130,8 +130,9 @@ def gotu_cmd(ctx, **kwargs):
     '--ambig/--no-ambig', default=True,
     help='Allow assigning one sequence to multiple classification units.')
 @click.option(
-    '--subok/--no-subok', default=True,
-    help='Allow assigning sequences to their subjects.')
+    '--subok', is_flag=True,
+    help=('In free-rank classification, allow assigning a sequence to its '
+          'direct subject, if applicable, before going up in hierarchy.'))
 @click.option(
     '--deidx/--no-deidx', default=False,
     help='Strip "_index" suffixes from subject IDs.')

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -85,7 +85,7 @@ def ordinal_mapper(fh, coords, fmt=None, n=1000000, th=0.8, prefix=False):
 
             # merge and sort coordinates
             # question is to merge an unsorted list into a sorted one
-            # Python's built-in "timesort" algorithm is efficient at this
+            # Python's built-in timsort algorithm is efficient at this
             try:
                 queue = sorted(coords[nucl] + loci)
 

--- a/woltka/tests/data/README.md
+++ b/woltka/tests/data/README.md
@@ -56,7 +56,6 @@ woltka classify \
   --map taxonomy/g2tid.txt \
   --nodes taxonomy/nodes.dmp \
   --rank free \
-  --no-subok \
   --output bowtie2.free.tsv
 ```
 

--- a/woltka/tests/test_cli.py
+++ b/woltka/tests/test_cli.py
@@ -69,8 +69,7 @@ class CliTests(TestCase):
                   '--output', output_fp,
                   '--nodes',  join(self.datdir, 'taxonomy', 'nodes.dmp'),
                   '--map',    join(self.datdir, 'taxonomy', 'g2tid.txt'),
-                  '--rank',   'free',
-                  '--no-subok']
+                  '--rank',   'free']
         _test_params(params, 'bowtie2.free.tsv')
 
         # blastn, multiplexed, lineage-based, species-level classification
@@ -107,7 +106,8 @@ class CliTests(TestCase):
         params = ['--input',  join(self.datdir, 'align', 'bt2sho'),
                   '--output', output_fp,
                   '--newick', join(self.datdir, 'tree.nwk'),
-                  '--rank',   'free']
+                  '--rank',   'free',
+                  '--subok']
         _test_params(params, 'bt2sho.phylo.tsv')
 
         # burst, classification by GO process

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -57,7 +57,7 @@ def workflow(input_fp:      str,
              above:        bool = False,
              major:        bool = None,
              ambig:        bool = True,
-             subok:        bool = True,
+             subok:        bool = False,
              deidx:        bool = False,
              # gene matching
              coords_fp:     str = None,
@@ -137,7 +137,7 @@ def classify(mapper:  object,
              above:     bool = False,
              major:      int = None,
              ambig:      str = True,
-             subok:     bool = None,
+             subok:     bool = False,
              deidx:     bool = False,
              lines:      int = None,
              stratmap:  dict = None) -> dict:
@@ -187,8 +187,8 @@ def classify(mapper:  object,
         the same rank. The profile will be normalized by the number of matches
         per query sequence.
     subok : bool, optional
-        Allow directly reporting subject ID(s) if a sequence cannot be assigned
-        to any higher classification unit.
+        In free-rank classification, allow assigning sequences to their direct
+        subjects instead of higher classification units, if applicable.
     deidx : bool, optional
         Strip "underscore index" suffixes from subject IDs.
     lines : int, optional
@@ -449,7 +449,7 @@ def build_mapper(coords_fp: str = None,
         with openzip(coords_fp) as fh:
             coords = read_gene_coords(fh, sort=True)
         click.echo(' Done.')
-        click.echo(f'Total number of host sequences: {len(coords)}.')
+        click.echo(f'  Total number of host sequences: {len(coords)}.')
         lines = lines or 1000000
         return partial(ordinal_mapper, coords=coords,
                        prefix=whether_prefix(coords),
@@ -723,7 +723,7 @@ def assign_readmap(qryque:    list,
                    above:     bool = False,
                    major:    float = None,
                    ambig:     bool = True,
-                   subok:     bool = None,
+                   subok:     bool = False,
                    strata:    dict = None):
     """Assign query sequences in a query-to-subjects map to classification
     units based on their subjects.
@@ -763,8 +763,8 @@ def assign_readmap(qryque:    list,
         Count occurrence of each possible assignment instead of targeting one
         assignment (available only with a fixed rank and not above).
     subok : bool, optional
-        Allow assignment to subject(s) itself instead of higher classification
-        units.
+        In free-rank classification, allow assigning sequences to their direct
+        subjects instead of higher classification units, if applicable.
     strata : dict, optional
         Read-to-feature map for stratification.
     """


### PR DESCRIPTION
The boolean flag `--subok` indicates that query sequences can be directly assigned to their subjects. This is only applicable (so far) in free-rank classification. I realized that having this switch off is the more common scenario. Also modified the description to make it more clear.