### PR TITLE
Call external programs for decompression.

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -81,8 +81,8 @@ Option | Description
 Option | Description
 --- | ---
 `--chunk` | Number of alignment lines to read and parse in each chunk. Default: 1,000 for plain mapping, or 1,000,000 for ordinal mapping.
-`--cache` | Number of recent classification results to cache for faster subsequent classifications. Default: 128.
-
+`--cache` | Number of recent classification results to cache for faster subsequent classifications. Default: 1024.
+`--no-exe` | Disable calling external programs (`gzip`, `bzip2` and `xz`) for decompression. Otherwise, Woltka will use them if available for faster processing, or switch back to Python if not.
 
 ## Tools
 

--- a/woltka/align.py
+++ b/woltka/align.py
@@ -55,9 +55,7 @@ def plain_mapper(fh, fmt=None, n=1000):
     proceeds.
     """
     # determine alignment file format
-    if not fmt:
-        fmt, head = infer_align_format(fh)
-        fh = chain(iter(head), fh)
+    fmt, head = (fmt, []) if fmt else infer_align_format(fh)
 
     # assign parser for given format
     parser = assign_parser(fmt)
@@ -71,7 +69,7 @@ def plain_mapper(fh, fmt=None, n=1000):
     # parse alignment file
     this = None  # current query Id
     target = n   # target line number at end of current chunk
-    for i, line in enumerate(fh):
+    for i, line in enumerate(chain(iter(head), fh)):
 
         # parse current alignment line
         try:

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -179,6 +179,9 @@ def gotu_cmd(ctx, **kwargs):
 @click.option(
     '--cache', type=click.INT, default=128,
     help='Number of recent results to cache for faster classification.')
+@click.option(
+    '--no-exe', is_flag=True,
+    help='Disable calling external programs for decompression.')
 def classify_cmd(**kwargs):
     """Generate a profile of samples based on a classification system.
     """

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -12,6 +12,7 @@
 """
 
 from collections import defaultdict
+from itertools import chain
 from operator import itemgetter
 
 from .align import infer_align_format, assign_parser
@@ -47,7 +48,9 @@ def ordinal_mapper(fh, coords, fmt=None, n=1000000, th=0.8, prefix=False):
         Subject(s) queue.
     """
     # determine file format
-    fmt = fmt or infer_align_format(fh)
+    if not fmt:
+        fmt, head = infer_align_format(fh)
+        fh = chain(iter(head), fh)
 
     # assign parser for given format
     parser = assign_parser(fmt)

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -48,9 +48,7 @@ def ordinal_mapper(fh, coords, fmt=None, n=1000000, th=0.8, prefix=False):
         Subject(s) queue.
     """
     # determine file format
-    if not fmt:
-        fmt, head = infer_align_format(fh)
-        fh = chain(iter(head), fh)
+    fmt, head = (fmt, []) if fmt else infer_align_format(fh)
 
     # assign parser for given format
     parser = assign_parser(fmt)
@@ -109,7 +107,7 @@ def ordinal_mapper(fh, coords, fmt=None, n=1000000, th=0.8, prefix=False):
     target = n   # target line number at end of current chunk
 
     # parse alignment file
-    for i, line in enumerate(fh):
+    for i, line in enumerate(chain(iter(head), fh)):
 
         # parse current alignment line
         try:

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -109,19 +109,21 @@ class AlignTests(TestCase):
         # simple cases
         # map
         line = 'S1/1	NC_123456'
-        self.assertEqual(infer_align_format(StringIO(line)), 'map')
+        obs = infer_align_format(StringIO(line))
+        self.assertEqual(obs[0], 'map')
+        self.assertListEqual(obs[1], [line])
 
         # b6o
         line = 'S1/1	NC_123456	100	100	0	0	1	100	25	124	0.1	100'
-        self.assertEqual(infer_align_format(StringIO(line)), 'b6o')
+        self.assertEqual(infer_align_format(StringIO(line))[0], 'b6o')
 
         # sam
         line = 'S1	77	NC_123456	26	0	100M	*	0	0	*	*'
-        self.assertEqual(infer_align_format(StringIO(line)), 'sam')
+        self.assertEqual(infer_align_format(StringIO(line))[0], 'sam')
 
         # sam header
         line = '@HD	VN:1.0	SO:unsorted'
-        self.assertEqual(infer_align_format(StringIO(line)), 'sam')
+        self.assertEqual(infer_align_format(StringIO(line))[0], 'sam')
 
         # empty file
         with self.assertRaises(ValueError) as ctx:
@@ -146,11 +148,11 @@ class AlignTests(TestCase):
         # real files
         # Bowtie2 (sam)
         with openzip(join(self.datdir, 'align', 'bowtie2', 'S01.sam.xz')) as f:
-            self.assertEqual(infer_align_format(f), 'sam')
+            self.assertEqual(infer_align_format(f)[0], 'sam')
 
         # BURST (b6o)
         with openzip(join(self.datdir, 'align', 'burst', 'S01.b6.bz2')) as f:
-            self.assertEqual(infer_align_format(f), 'b6o')
+            self.assertEqual(infer_align_format(f)[0], 'b6o')
 
     def test_assign_parser(self):
         self.assertEqual(assign_parser('map'), parse_map_line)

--- a/woltka/tests/test_cli.py
+++ b/woltka/tests/test_cli.py
@@ -64,7 +64,7 @@ class CliTests(TestCase):
         output_fp = join(self.tmpdir, 'output.tsv')
 
         def _test_params(params, exp):
-            res = self.runner.invoke(classify_cmd, params)
+            res = self.runner.invoke(classify_cmd, params + ['--no-exe'])
             self.assertEqual(res.exit_code, 0)
             self.assertTrue(cmp(output_fp, join(self.outdir, exp)))
 

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -265,8 +265,8 @@ def classify(mapper:  object,
 
                     # (optional) read strata of current sample into cache
                     if stratmap and sample != csample:
-                        with readzip(stratmap[sample], zippers) as fh:
-                            kwargs['strata'] = dict(read_map_uniq(fh))
+                        with readzip(stratmap[sample], zippers) as fhs:
+                            kwargs['strata'] = dict(read_map_uniq(fhs))
                         csample = sample
 
                     # call assignment workflow for each rank


### PR DESCRIPTION
Python's built-in compression modules (`gzip`, `bz2` and `lzma`) are slow, whereas calling external programs is much faster. This simple change improves performance by 100%+.