### PR TITLE
handled zero length alignment

### DIFF
--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -115,6 +115,10 @@ def ordinal_mapper(fh, coords, fmt=None, n=1000000, th=0.8, prefix=False):
         except (TypeError, IndexError):
             continue
 
+        # skip if length is not available
+        if not length:
+            continue
+
         # when query Id changes and chunk limits has been reached
         if query != this and i >= target:
 

--- a/woltka/tests/test_ordinal.py
+++ b/woltka/tests/test_ordinal.py
@@ -144,6 +144,7 @@ class OrdinalTests(TestCase):
             'r7	n1	95	20	0	0	25	6	79	60	1	1',
             'r8	n1	95	20	0	0	1	20	84	65	1	1',
             'r9	n1	95	20	0	0	1	20	95	82	1	1',
+            'rx	nx	95	0	0	0	0	0	0	0	1	1',
             '# end of file')))
         obs = list(ordinal_mapper(aln, coords))[0]
         exp = [('r1', 'g1'),


### PR DESCRIPTION
In some situations, an alignment record may appear to be intact, but the length of the alignment is zero or not available. This happens when one runs Bowtie2 with default parameters on a paired-end sequencing dataset, which could result in some lines whose CIGAR is "*" (not available). This patch lets the program skip lines without alignment length, rather than raise an error.