### PR TITLE
Fixed free-rank classification no target issue

### DIFF
--- a/doc/classify.md
+++ b/doc/classify.md
@@ -40,6 +40,10 @@ The difference from free-rank classification (2) is that, it discards all units 
 
 Multiple ranks can be specified simultaneously, delimited by comma (e.g., `--rank none,free,phylum,genus,species`), in which case Woltka will generate one [profile](output.md) for each rank. This is significantly faster than running Woltka multiple times on individual ranks.
 
+### Default rank
+
+One can omit the `--rank` parameter. In such case, Woltka automatically performs free-rank classification (2) (same as `--rank free`) if there is a classification system, or no classification (1) (same as `--rank none`) if there isn't.
+
 
 ## Ambiguous assignment
 

--- a/doc/hierarchy.md
+++ b/doc/hierarchy.md
@@ -4,7 +4,7 @@ Woltka features a highly flexible hierarchical classification system. It is repr
 
 The term "**rank**" (or "level") is still relevant, but it is merely a property of a feature, and does not bear information of hierarchy. For example, above a _genus_-level unit it does not have to be a _family_-level one, but could directly go to _order_, or have a _tribe_ which isn't common for the rest of the tree, or one or more nodes which do NOT have the rank assignment.
 
-In another word, Woltka classification is **rank-free**. This design enables finer-grain resolution of feature relationships, in addition to flexibility. It is therefore suitable for complex systems, such as phylogenetic trees.
+In another word, Woltka classification is **rank-independent**. This design enables finer-grain resolution of feature relationships, in addition to flexibility. It is therefore suitable for complex systems, such as phylogenetic trees.
 
 That being said, Woltka still supports ranked hierarchies and one can instruct the program to target one or more specific ranks.
 

--- a/doc/wolsop.sh
+++ b/doc/wolsop.sh
@@ -79,7 +79,7 @@ if [ "$taxtree" == taxdump ]; then
 else
   woltka classify \
     --input   $input \
-    --lineage $db/taxonomy/lineage.txt \
+    --lineage $db/taxonomy/lineages.txt \
     --rank    none,free,$taxranks \
     $filext \
     $altfmt \

--- a/woltka/classify.py
+++ b/woltka/classify.py
@@ -65,7 +65,7 @@ def assign_free(subs, tree, root=None, subok=False):
     """
     try:
         sub, = subs
-        return sub if subok else tree[sub]
+        return sub if subok else (tree[sub] if sub in tree else None)
     except ValueError:
         lca = find_lca(subs, tree)
         return None if lca == root else lca

--- a/woltka/tests/test_classify.py
+++ b/woltka/tests/test_classify.py
@@ -59,6 +59,10 @@ class ClassifyTests(TestCase):
         obs = assign_free({'G1'}, **kwargs, subok=True)
         self.assertEqual(obs, 'G1')
 
+        # assign one sub to nothing
+        obs = assign_free({'Gx'}, **kwargs)
+        self.assertIsNone(obs)
+
     def test_assign_rank(self):
         tree = {'G1': 'T1', 'G2': 'T1', 'G3': 'T2',
                 'T1': 'T0', 'T2': 'T0', 'T0': 'T0'}


### PR DESCRIPTION
Previously, with free-rank classification, if the subject is not found in the classification system, the program will raise an error. However, some realistic classification system don't work that way. For example, the following command:

```bash
woltka classify -i input.sam -c coords.txt -m metacyc.map -o output.tsv
```

Will fail if one or more ORFs are not found in the mapping file, which is highly likely.

This issue was found by @droush .

This patch allows the program to bypass (more specifically, return `None`) these instances.

It may slow down the algorithm marginally, though.