### PR TITLE
Reduced coverage file size

### DIFF
--- a/woltka/tests/test_coverage.py
+++ b/woltka/tests/test_coverage.py
@@ -15,7 +15,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 from woltka.coverage import (
-    merge_ranges, parse_ranges, calc_coverage, write_coverage)
+    merge_ranges, parse_ranges, calc_coverage, write_coverage, trim_digits)
 
 
 class CoverageTests(TestCase):
@@ -107,25 +107,32 @@ class CoverageTests(TestCase):
                'S2': {'G2': [26, 100, 151, 200],
                       'G3': [1, 50, 76, 125],
                       'G4': [26, 75, 101, 150]},
-               'S3': {'G1': [1, 200],
+               'S3': {'G1': [1, 200, 250, 250],
                       'G2': [1, 100]}}
         outdir = join(self.tmpdir, 'outdir')
         makedirs(outdir)
         write_coverage(cov, outdir)
         with open(join(outdir, 'S1.cov'), 'r') as f:
             obs = f.read().splitlines()
-        exp = ['G1\t1\t100', 'G1\t251\t300', 'G2\t101\t150']
+        exp = ['G1\t1-100,251-300', 'G2\t101-50']
         self.assertListEqual(obs, exp)
         with open(join(outdir, 'S2.cov'), 'r') as f:
             obs = f.read().splitlines()
-        exp = ['G2\t26\t100', 'G2\t151\t200', 'G3\t1\t50',
-               'G3\t76\t125', 'G4\t26\t75', 'G4\t101\t150']
+        exp = ['G2\t26-100,51-200', 'G3\t1-50,76-125', 'G4\t26-75,101-50']
         self.assertListEqual(obs, exp)
         with open(join(outdir, 'S3.cov'), 'r') as f:
             obs = f.read().splitlines()
-        exp = ['G1\t1\t200', 'G2\t1\t100']
+        exp = ['G1\t1-200,50', 'G2\t1-100']
         self.assertListEqual(obs, exp)
         rmtree(outdir)
+
+    def test_trim_digits(self):
+        self.assertEqual(trim_digits('0', '5'), '5')
+        self.assertEqual(trim_digits('0', '15'), '15')
+        self.assertEqual(trim_digits('10', '15'), '5')
+        self.assertEqual(trim_digits('15', '25'), '25')
+        self.assertEqual(trim_digits('20', '105'), '105')
+        self.assertIsNone(trim_digits('35', '35'))
 
 
 if __name__ == '__main__':

--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -53,9 +53,9 @@ class WorkflowTests(TestCase):
         workflow(input_fp, output_fp, outcov_dir=outcov_dir)['none']
         with open(join(outcov_dir, 'S04.cov'), 'r') as f:
             obs = f.read().splitlines()
-        self.assertEqual(len(obs), 1078)
-        self.assertEqual(obs[10], 'G000007265\t2092666\t2092815')
-        self.assertEqual(obs[200], 'G000215745\t768758\t769038')
+        self.assertEqual(len(obs), 10)
+        self.assertEqual(obs[0][:30], 'G000007265\t72683-939,264689-93')
+        self.assertEqual(obs[5][:30], 'G000195715\t367058-346,600305-4')
         remove(output_fp)
         rmtree(outcov_dir)
 


### PR DESCRIPTION
The coverage files are big. So I made some tweaks to reduce its size while maintaining human readability.

Previously, the file is like:

```
G1	1	120
G1	145	180
G1	195	235
G1	250	250
G1	270	360
G1	365	390
G1	395	420
...
```
Now it is like:
```
G1	1-120,45-80,95-235,50,70-360,5-90,5-420,...
```

In a small-scale test, this treatment reduced the output file size from 11744975 to 4022174 (65.8% decrease). If we gzip the files (note: Woltka supports zipping output files using Gzip, Bzip2 and Xz), the file size reduced from 3358089 to 1775954 (47.1%) decrease.

If we adopt this design, the downstream analysis (Zebra filter?) also needs to be modified to take this format.

What do you think? @dhakim87 @ElDeveloper