### PR TITLE
Optimized alignment file processing

### DIFF
--- a/woltka/align.py
+++ b/woltka/align.py
@@ -497,3 +497,56 @@ def parse_centrifuge(fh):
         if not line.startswith('readID'):
             x = line.split('\t')
             yield x[0], x[1], int(x[3]), int(x[5])
+
+
+def parse_sam_file_pd(fh, n=65536):
+    """Parse a SAM file (sam) using Pandas.
+
+    Parameters
+    ----------
+    fh : file handle
+        SAM file to parse.
+    n : int, optional
+        Chunk size.
+
+    Yields
+    ------
+    None
+
+    Notes
+    -----
+    This is a SAM file parser using Pandas. It is slower than the current
+    parser. The `read_csv` is fast, but the data frame manipulation slows
+    down the process. It is here for reference only.
+    """
+    return
+    # with pd.read_csv(fp, sep='\t',
+    #                  header=None,
+    #                  comment='@',
+    #                  na_values='*',
+    #                  usecols=[0, 1, 2, 3, 5],
+    #                  names=['qname', 'flag', 'rname', 'pos', 'cigar'],
+    #                  dtype={'qname': str,
+    #                         'flag':  np.uint16,
+    #                         'rname': str,
+    #                         'pos':   int,
+    #                         'cigar': str},
+    #                  chunksize=n) as reader:
+    #     for chunk in reader:
+    #         chunk.dropna(subset=['rname'], inplace=True)
+    #         # this is slow, because of function all
+    #         chunk['length'], offset = zip(*chunk['cigar'].apply(
+    #             cigar_to_lens))
+    #         chunk['right'] = chunk['pos'] + offset - 1
+    #         # this is slow, because of function all
+    #         # chunk['qname'] = chunk[['qname', 'flag']].apply(
+    #         #   qname_by_flag, axis=1)
+    #         # this is a faster method
+    #         chunk['qname'] += np.where(
+    #             chunk['qname'].str[-2:].isin(('/1', '/2')), '',
+    #             np.where(np.bitwise_and(chunk['flag'], (1 << 6)), '/1',
+    #                      np.where(np.bitwise_and(chunk['flag'], (1 << 7)),
+    #                      '/2', '')))
+    #         chunk['score'] = 0
+    #         yield from chunk[['qname', 'rname', 'score', 'length',
+    #                           'pos', 'right']].values

--- a/woltka/align.py
+++ b/woltka/align.py
@@ -366,17 +366,18 @@ def parse_sam_file(fh):
     including readlines(chunk), csv.reader, and pd_read_csv(chunk). They were
     slower.
     """
-    line = None  # not necessary, but in case
+    last = None
 
     # parse head
     for line in fh:
 
         # currently, it just skips head
         if line[0] != '@':
+            last = line
             break
 
     # include current line
-    it = chain([line], fh) if line else fh
+    it = chain([last], fh) if last else fh
 
     # parse body
     for line in it:
@@ -416,12 +417,13 @@ def parse_sam_file_ext(fh):
     tuple of (str, str, None, int, int, int)
         Query, subject, None, length, start, end.
     """
-    line = None
+    last = None
     for line in fh:
         if line[0] != '@':
+            last = line
             break
 
-    it = chain([line], fh) if line else fh
+    it = chain([last], fh) if last else fh
     for line in it:
 
         # relevant fields

--- a/woltka/align.py
+++ b/woltka/align.py
@@ -409,6 +409,41 @@ def cigar_to_lens(cigar):
     return align, align + offset
 
 
+def cigar_to_lens_ord(cigar):
+    """Extract lengths from a CIGAR string.
+
+    Parameters
+    ----------
+    cigar : str
+        CIGAR string.
+
+    Returns
+    -------
+    int
+        Alignment length.
+    int
+        Offset in subject sequence.
+
+    Notes
+    -----
+    This is an alternative solution based on unicode numbers of characters.
+    It is slower than the currently adopted solution. But since it is purely
+    based on numbers, there may be room for future optimization.
+    """
+    align, offset = 0, 0
+    n = 0
+    for c in map(ord, cigar):
+        if c < 60:
+            n = n * 10 + c - 48
+        else:
+            if c in (77, 88, 61):
+                align += n
+            elif c in (68, 78):
+                offset += n
+            n = 0
+    return align, align + offset
+
+
 def parse_kraken(fh):
     """Parse a Kraken mapping file.
 

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -54,7 +54,7 @@ def ordinal_mapper(fh, coords, idmap, fmt=None, n=1000000, th=0.8,
     fmt, head = (fmt, []) if fmt else infer_align_format(fh)
 
     # assign parser for given format
-    parser = assign_parser(fmt)
+    parser = assign_parser(fmt, ext=True)
 
     # cached list of query Ids for reverse look-up
     # gene Ids are unique, but read Ids can have duplicates (i.e., one read is

--- a/woltka/ordinal.py
+++ b/woltka/ordinal.py
@@ -122,13 +122,8 @@ def ordinal_mapper(fh, coords, idmap, fmt=None, n=1000000, th=0.8,
     target = n   # target line number at end of current chunk
 
     # parse alignment file
-    for i, line in enumerate(chain(iter(head), fh)):
-
-        # parse current alignment line
-        try:
-            query, subject, _, length, beg, end = parser(line)[:6]
-        except (TypeError, IndexError):
-            continue
+    for i, row in enumerate(parser(chain(iter(head), fh))):
+        query, subject, _, length, beg, end = row[:6]
 
         # skip if length is not available or zero
         if not length:
@@ -198,11 +193,8 @@ def ordinal_parser_dummy(fh, parser):
     lenmap = defaultdict(dict)
     locmap = defaultdict(list)
 
-    for line in fh:
-        try:
-            query, subject, _, length, start, end = parser(line)[:6]
-        except (TypeError, IndexError):
-            continue
+    for row in parser(fh):
+        query, subject, _, length, start, end = row[:6]
         idx = len(rids)
         rids.append(query)
         lenmap[subject][idx] = length

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -18,7 +18,7 @@ from woltka.file import openzip
 from woltka.align import (
     plain_mapper, range_mapper, infer_align_format, assign_parser,
     parse_map_file, parse_b6o_file, parse_sam_file, cigar_to_lens,
-    cigar_to_lens_ord, parse_kraken, parse_centrifuge)
+    cigar_to_lens_ord, parse_kraken, parse_centrifuge, parse_sam_file_pd)
 
 
 class AlignTests(TestCase):
@@ -253,6 +253,9 @@ class AlignTests(TestCase):
         self.assertEqual(len(obs), 1)
         exp = [('S1', 'NC_123456', 125, 50)]
         self.assertTupleEqual(obs[0], exp[0])
+
+    def test_parse_sam_file_pd(self):
+        self.assertIsNone(parse_sam_file_pd([]))
 
 
 if __name__ == '__main__':

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -225,12 +225,12 @@ class AlignTests(TestCase):
         self.assertTupleEqual(obs[1], exp[1])
 
     def test_parse_sam_file(self):
-        sam = (
+        sam = iter((
             '@HD	VN:1.0	SO:unsorted',
             'S1	77	NC_123456	26	0	100M	*	0	0	*	*',
             'S1	141	NC_123456	151	0	80M	*	0	0	*	*',
             'S2	0	NC_789012	186	0	50M5I20M5D20M	*	0	0	*	*',
-            'S2	16	*	0	0	*	*	0	0	*	*')
+            'S2	16	*	0	0	*	*	0	0	*	*'))
         obs = list(parse_sam_file(sam))
         self.assertEqual(len(obs), 3)
         exp = [('S1/1', 'NC_123456'),
@@ -245,26 +245,25 @@ class AlignTests(TestCase):
         self.assertTupleEqual(obs[2], exp[2])
         # 5th line: not aligned
 
+        # file is empty
+        obs = list(parse_sam_file_ext(iter(())))
+        self.assertEqual(len(obs), 0)
+
     def test_parse_sam_file_ext(self):
-        sam = (
+        sam = iter((
             '@HD	VN:1.0	SO:unsorted',
             'S1	77	NC_123456	26	0	100M	*	0	0	*	*',
             'S1	141	NC_123456	151	0	80M	*	0	0	*	*',
             'S2	0	NC_789012	186	0	50M5I20M5D20M	*	0	0	*	*',
-            'S2	16	*	0	0	*	*	0	0	*	*')
+            'S2	16	*	0	0	*	*	0	0	*	*'))
         obs = list(parse_sam_file_ext(sam))
         self.assertEqual(len(obs), 3)
         exp = [('S1/1', 'NC_123456', None, 100, 26, 125),
                ('S1/2', 'NC_123456', None, 80, 151, 230),
                ('S2', 'NC_789012', None, 90, 186, 280)]
-        # 1st line: header
-        # 2nd line: normal, fully-aligned, forward strand
         self.assertTupleEqual(obs[0], exp[0])
-        # 3rd line: shortened, reverse strand
         self.assertTupleEqual(obs[1], exp[1])
-        # 4th line: not perfectly aligned, unpaired
         self.assertTupleEqual(obs[2], exp[2])
-        # 5th line: not aligned
 
     def test_cigar_to_lens(self):
         self.assertTupleEqual(cigar_to_lens('150M'), (150, 150))

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -245,8 +245,16 @@ class AlignTests(TestCase):
         self.assertTupleEqual(obs[2], exp[2])
         # 5th line: not aligned
 
+        # header only
+        sam = iter((
+            '@HD	VN:1.0	SO:unsorted',
+            '@SQ	SN:G000005825	LN:4249288',
+            '@SQ	SN:G000006175	LN:1936387'))
+        obs = list(parse_sam_file(sam))
+        self.assertEqual(len(obs), 0)
+
         # file is empty
-        obs = list(parse_sam_file_ext(iter(())))
+        obs = list(parse_sam_file(iter(())))
         self.assertEqual(len(obs), 0)
 
     def test_parse_sam_file_ext(self):
@@ -264,6 +272,9 @@ class AlignTests(TestCase):
         self.assertTupleEqual(obs[0], exp[0])
         self.assertTupleEqual(obs[1], exp[1])
         self.assertTupleEqual(obs[2], exp[2])
+
+        obs = list(parse_sam_file_ext(iter(())))
+        self.assertEqual(len(obs), 0)
 
     def test_cigar_to_lens(self):
         self.assertTupleEqual(cigar_to_lens('150M'), (150, 150))

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -17,7 +17,7 @@ from io import StringIO
 from woltka.file import openzip
 from woltka.align import (
     plain_mapper, range_mapper, infer_align_format, assign_parser,
-    parse_map_line, parse_b6o_line, parse_sam_line, cigar_to_lens,
+    parse_map_file, parse_b6o_file, parse_sam_file, cigar_to_lens,
     parse_kraken, parse_centrifuge)
 
 
@@ -178,68 +178,56 @@ class AlignTests(TestCase):
             self.assertEqual(infer_align_format(f)[0], 'b6o')
 
     def test_assign_parser(self):
-        self.assertEqual(assign_parser('map'), parse_map_line)
-        self.assertEqual(assign_parser('sam'), parse_sam_line)
-        self.assertEqual(assign_parser('b6o'), parse_b6o_line)
+        self.assertEqual(assign_parser('map'), parse_map_file)
+        self.assertEqual(assign_parser('sam'), parse_sam_file)
+        self.assertEqual(assign_parser('b6o'), parse_b6o_file)
         with self.assertRaises(ValueError) as ctx:
             assign_parser('xyz')
         self.assertEqual(str(ctx.exception), (
             'Invalid format code: "xyz".'))
 
-    def test_parse_map_line(self):
-        aln = ('R1	G1', 'R2	G2	# note', '# end of file')
+    def test_parse_map_file(self):
+        aln = (
+            'R1	G1',          # 1st line (normal)
+            'R2	G2	# note',  # 2nd line (with additional column)
+            '# end of file')  # 3rd line (not tab-delimited)
+        obs = list(parse_map_file(aln))
+        self.assertEqual(len(obs), 2)
+        self.assertTupleEqual(obs[0], ('R1', 'G1'))
+        self.assertTupleEqual(obs[1], ('R2', 'G2'))
 
-        # first line
-        self.assertTupleEqual(parse_map_line(aln[0]), ('R1', 'G1'))
+    def test_parse_b6o_file(self):
+        b6o = (
+            '# BLAST result:',
+            'S1/1	NC_123456	100	100	0	0	1	100	225	324	1.2e-30	345',
+            'S1/2	NC_123456	95	98	2	1	2	99	708	608	3.4e-20	270')
+        obs = list(parse_b6o_file(b6o))
+        self.assertEqual(len(obs), 2)
+        exp = [('S1/1', 'NC_123456', 345, 100, 225, 324),
+               ('S1/2', 'NC_123456', 270, 98, 608, 708)]
+        self.assertTupleEqual(obs[0], exp[0])
+        self.assertTupleEqual(obs[1], exp[1])
 
-        # second line (with additional column)
-        self.assertTupleEqual(parse_map_line(aln[1]), ('R2', 'G2'))
-
-        # third line (not tab-delimited)
-        self.assertIsNone(parse_map_line(aln[2]))
-
-    def test_parse_b6o_line(self):
-        b6o = ('S1/1	NC_123456	100	100	0	0	1	100	225	324	1.2e-30	345',
-               'S1/2	NC_123456	95	98	2	1	2	99	708	608	3.4e-20	270')
-
-        # first line
-        obs = parse_b6o_line(b6o[0])
-        exp = ('S1/1', 'NC_123456', 345, 100, 225, 324)
-        self.assertTupleEqual(obs, exp)
-
-        # second line
-        obs = parse_b6o_line(b6o[1])
-        exp = ('S1/2', 'NC_123456', 270, 98, 608, 708)
-        self.assertTupleEqual(obs, exp)
-
-    def test_parse_sam_line(self):
+    def test_parse_sam_file(self):
         sam = (
             '@HD	VN:1.0	SO:unsorted',
             'S1	77	NC_123456	26	0	100M	*	0	0	*	*',
             'S1	141	NC_123456	151	0	80M	*	0	0	*	*',
             'S2	0	NC_789012	186	0	50M5I20M5D20M	*	0	0	*	*',
             'S2	16	*	0	0	*	*	0	0	*	*')
-
-        # header
-        self.assertIsNone(parse_sam_line(sam[0]))
-
-        # normal, fully-aligned, forward strand
-        obs = parse_sam_line(sam[1])
-        exp = ('S1/1', 'NC_123456', None, 100, 26, 125)
-        self.assertTupleEqual(obs, exp)
-
-        # shortened, reverse strand
-        obs = parse_sam_line(sam[2])
-        exp = ('S1/2', 'NC_123456', None, 80, 151, 230)
-        self.assertTupleEqual(obs, exp)
-
-        # not perfectly aligned, unpaired
-        obs = parse_sam_line(sam[3])
-        exp = ('S2', 'NC_789012', None, 90, 186, 280)
-        self.assertTupleEqual(obs, exp)
-
-        # not aligned
-        self.assertIsNone(parse_sam_line(sam[4]))
+        obs = list(parse_sam_file(sam))
+        self.assertEqual(len(obs), 3)
+        exp = [('S1/1', 'NC_123456', None, 100, 26, 125),
+               ('S1/2', 'NC_123456', None, 80, 151, 230),
+               ('S2', 'NC_789012', None, 90, 186, 280)]
+        # 1st line: header
+        # 2nd line: normal, fully-aligned, forward strand
+        self.assertTupleEqual(obs[0], exp[0])
+        # 3rd line: shortened, reverse strand
+        self.assertTupleEqual(obs[1], exp[1])
+        # 4th line: not perfectly aligned, unpaired
+        self.assertTupleEqual(obs[2], exp[2])
+        # 5th line: not aligned
 
     def test_cigar_to_lens(self):
         self.assertTupleEqual(cigar_to_lens('150M'), (150, 150))
@@ -248,22 +236,19 @@ class AlignTests(TestCase):
     def test_parse_kraken(self):
         kra = ('C	S1	561	150	561:100 A:10 562:40',
                'U	S2	0	150	1:80 A:40 0:20 A:10')
-        obs = parse_kraken(kra[0])
-        exp = ('S1', '561')
-        self.assertTupleEqual(obs, exp)
-        obs = parse_kraken(kra[1])
-        exp = (None, None)
-        self.assertTupleEqual(obs, exp)
+        obs = list(parse_kraken(kra))
+        self.assertEqual(len(obs), 1)
+        exp = [('S1', '561')]
+        self.assertTupleEqual(obs[0], exp[0])
 
     def test_parse_centrifuge(self):
         cen = ('readID	seqID	taxID	score	2ndBestScore	'
                'hitLength	queryLength	numMatches',
                'S1	NC_123456	561	125	0	50	150	1')
-        obs = parse_centrifuge(cen[0])
-        self.assertIsNone(obs)
-        obs = parse_centrifuge(cen[1])
-        exp = ('S1', 'NC_123456', 125, 50)
-        self.assertTupleEqual(obs, exp)
+        obs = list(parse_centrifuge(cen))
+        self.assertEqual(len(obs), 1)
+        exp = [('S1', 'NC_123456', 125, 50)]
+        self.assertTupleEqual(obs[0], exp[0])
 
 
 if __name__ == '__main__':

--- a/woltka/tests/test_align.py
+++ b/woltka/tests/test_align.py
@@ -18,7 +18,7 @@ from woltka.file import openzip
 from woltka.align import (
     plain_mapper, range_mapper, infer_align_format, assign_parser,
     parse_map_file, parse_b6o_file, parse_sam_file, cigar_to_lens,
-    parse_kraken, parse_centrifuge)
+    cigar_to_lens_ord, parse_kraken, parse_centrifuge)
 
 
 class AlignTests(TestCase):
@@ -232,6 +232,10 @@ class AlignTests(TestCase):
     def test_cigar_to_lens(self):
         self.assertTupleEqual(cigar_to_lens('150M'), (150, 150))
         self.assertTupleEqual(cigar_to_lens('3M1I3M1D5M'), (11, 12))
+
+    def test_cigar_to_lens_ord(self):
+        self.assertTupleEqual(cigar_to_lens_ord('150M'), (150, 150))
+        self.assertTupleEqual(cigar_to_lens_ord('3M1I3M1D5M'), (11, 12))
 
     def test_parse_kraken(self):
         kra = ('C	S1	561	150	561:100 A:10 562:40',

--- a/woltka/tests/test_ordinal.py
+++ b/woltka/tests/test_ordinal.py
@@ -248,7 +248,7 @@ class OrdinalTests(TestCase):
             (608, True, False, 1), (708, False, False, 1)]})
 
         # sam (BWA, Bowtie2, Minimap2 etc.)
-        sam = (
+        sam = iter((
             # SAM header to be ignored
             '@HD	VN:1.0	SO:unsorted',
             # normal, fully-aligned, forward strand
@@ -258,7 +258,7 @@ class OrdinalTests(TestCase):
             # not perfectly aligned, unpaired
             'S2	0	NC_789012	186	0	50M5I20M5D20M	*	0	0	*	*',
             # unaligned
-            'S2	16	*	0	0	*	*	0	0	*	*')
+            'S2	16	*	0	0	*	*	0	0	*	*'))
         obs = ordinal_parser_dummy(sam, parse_sam_file_ext)
         self.assertListEqual(obs[0], ['S1/1', 'S1/2', 'S2'])
         self.assertDictEqual(obs[1], {

--- a/woltka/tests/test_ordinal.py
+++ b/woltka/tests/test_ordinal.py
@@ -20,7 +20,7 @@ from io import StringIO
 from functools import partial
 
 from woltka.file import openzip
-from woltka.align import parse_b6o_line, parse_sam_line
+from woltka.align import parse_b6o_file, parse_sam_file
 from woltka.ordinal import (
     match_read_gene_dummy, match_read_gene, match_read_gene_naive,
     match_read_gene_quart, ordinal_parser_dummy, ordinal_mapper,
@@ -240,8 +240,7 @@ class OrdinalTests(TestCase):
         b6o = (
             'S1/1	NC_123456	100	100	0	0	1	100	225	324	1.2e-30	345',
             'S1/2	NC_123456	95	98	2	1	2	99	708	608	3.4e-20	270')
-        parser = parse_b6o_line
-        obs = ordinal_parser_dummy(b6o, parser)
+        obs = ordinal_parser_dummy(b6o, parse_b6o_file)
         self.assertListEqual(obs[0], ['S1/1', 'S1/2'])
         self.assertDictEqual(obs[1], {'NC_123456': {0: 100, 1: 98}})
         self.assertDictEqual(obs[2], {'NC_123456': [
@@ -260,8 +259,7 @@ class OrdinalTests(TestCase):
             'S2	0	NC_789012	186	0	50M5I20M5D20M	*	0	0	*	*',
             # unaligned
             'S2	16	*	0	0	*	*	0	0	*	*')
-        parser = parse_sam_line
-        obs = ordinal_parser_dummy(sam, parser)
+        obs = ordinal_parser_dummy(sam, parse_sam_file)
         self.assertListEqual(obs[0], ['S1/1', 'S1/2', 'S2'])
         self.assertDictEqual(obs[1], {
             'NC_123456': {0: 100, 1: 80},

--- a/woltka/tests/test_ordinal.py
+++ b/woltka/tests/test_ordinal.py
@@ -20,7 +20,7 @@ from io import StringIO
 from functools import partial
 
 from woltka.file import openzip
-from woltka.align import parse_b6o_file, parse_sam_file
+from woltka.align import parse_b6o_file_ext, parse_sam_file_ext
 from woltka.ordinal import (
     match_read_gene_dummy, match_read_gene, match_read_gene_naive,
     match_read_gene_quart, ordinal_parser_dummy, ordinal_mapper,
@@ -240,7 +240,7 @@ class OrdinalTests(TestCase):
         b6o = (
             'S1/1	NC_123456	100	100	0	0	1	100	225	324	1.2e-30	345',
             'S1/2	NC_123456	95	98	2	1	2	99	708	608	3.4e-20	270')
-        obs = ordinal_parser_dummy(b6o, parse_b6o_file)
+        obs = ordinal_parser_dummy(b6o, parse_b6o_file_ext)
         self.assertListEqual(obs[0], ['S1/1', 'S1/2'])
         self.assertDictEqual(obs[1], {'NC_123456': {0: 100, 1: 98}})
         self.assertDictEqual(obs[2], {'NC_123456': [
@@ -259,7 +259,7 @@ class OrdinalTests(TestCase):
             'S2	0	NC_789012	186	0	50M5I20M5D20M	*	0	0	*	*',
             # unaligned
             'S2	16	*	0	0	*	*	0	0	*	*')
-        obs = ordinal_parser_dummy(sam, parse_sam_file)
+        obs = ordinal_parser_dummy(sam, parse_sam_file_ext)
         self.assertListEqual(obs[0], ['S1/1', 'S1/2', 'S2'])
         self.assertDictEqual(obs[1], {
             'NC_123456': {0: 100, 1: 80},


### PR DESCRIPTION
I made attempts to improve file processing speed. The improvement is marginal. That's probably because the previous version was already quite optimized. In a typical task, I got:

Before: 0:20.27, After: 0:20.19

Meanwhile, just zcat alignment files > /dev/null without going through Woltka took 0:14.44. This may indicate that there isn't much room to optimize this part of the program.