### PR TITLE
fixed collapse field 1 bug

### DIFF
--- a/woltka/biom.py
+++ b/woltka/biom.py
@@ -230,7 +230,7 @@ def collapse_biom(table: biom.Table, mapping: dict, divide=False, field=None):
     metadata = {}
     for id_ in table.ids('observation'):
         feature = id_
-        if field:
+        if field is not None:
             fields = feature.split('|')
             try:
                 feature = fields[field]
@@ -241,7 +241,7 @@ def collapse_biom(table: biom.Table, mapping: dict, divide=False, field=None):
             continue
         targets = []
         for target in mapping[feature]:
-            if field:
+            if field is not None:
                 fields[field] = target
                 target = '|'.join(fields)
             targets.append(target)

--- a/woltka/table.py
+++ b/woltka/table.py
@@ -597,7 +597,7 @@ def collapse_table(table, mapping, divide=False, field=None):
     width = len(samples)
     res = defaultdict(lambda: [0] * width)
     for datum, feature in zip(*table[:2]):
-        if field:
+        if field is not None:
             fields = feature.split('|')
             try:
                 feature = fields[field]
@@ -611,7 +611,7 @@ def collapse_table(table, mapping, divide=False, field=None):
             k = 1 / len(targets)
             datum = [x * k for x in datum]
         for target in targets:
-            if field:
+            if field is not None:
                 fields[field] = target
                 target = '|'.join(fields)
             res[target] = list(map(add, res[target], datum))

--- a/woltka/tests/test_biom.py
+++ b/woltka/tests/test_biom.py
@@ -292,6 +292,12 @@ class BiomTests(TestCase):
         table = Table(*map(np.array, prep_table({
             'S1': {'A|K1': 4, 'A|K2': 5, 'B|K2': 8, 'C|K3': 3, 'C|K4': 0},
             'S2': {'A|K1': 1, 'A|K2': 8, 'B|K2': 0, 'C|K3': 4, 'C|K4': 2}})))
+        mapping = {'A': ['1'], 'B': ['1']}
+        obs = collapse_biom(table.copy(), mapping, field=0)
+        exp = Table(*map(np.array, prep_table({
+            'S1': {'1|K1': 4, '1|K2': 13},
+            'S2': {'1|K1': 1, '1|K2': 8}})))
+        self.assertEqual(obs.descriptive_equality(exp), 'Tables appear equal')
         mapping = {'K1': ['H1'], 'K2': ['H2', 'H3'], 'K3': ['H3']}
         obs = collapse_biom(table.copy(), mapping, field=1)
         exp = Table(*map(np.array, prep_table({

--- a/woltka/tests/test_table.py
+++ b/woltka/tests/test_table.py
@@ -134,12 +134,12 @@ class TableTests(TestCase):
     def test_read_table(self):
         # read a BIOM table
         fp = join(self.datdir, 'output', 'blastn.species.biom')
-        table, fmt = read_table(fp)
+        _, fmt = read_table(fp)
         self.assertEqual(fmt, 'biom')
 
         # read a TSV file
         fp = join(self.datdir, 'output', 'blastn.species.tsv')
-        table, fmt = read_table(fp)
+        _, fmt = read_table(fp)
         self.assertEqual(fmt, 'tsv')
 
         # wrong encoding
@@ -728,6 +728,13 @@ class TableTests(TestCase):
         table = prep_table({
             'S1': {'A|K1': 4, 'A|K2': 5, 'B|K2': 8, 'C|K3': 3, 'C|K4': 0},
             'S2': {'A|K1': 1, 'A|K2': 8, 'B|K2': 0, 'C|K3': 4, 'C|K4': 2}})
+        mapping = {'A': ['1'], 'B': ['1']}
+        obs = collapse_table(table, mapping, field=0)
+        exp = prep_table({
+            'S1': {'1|K1': 4, '1|K2': 13},
+            'S2': {'1|K1': 1, '1|K2': 8}})
+        for i in range(4):
+            self.assertListEqual(obs[i], exp[i])
         mapping = {'K1': ['H1'], 'K2': ['H2', 'H3'], 'K3': ['H3']}
         obs = collapse_table(table, mapping, field=1)
         exp = prep_table({


### PR DESCRIPTION
The bug was as follows: if a profile is stratified, and the user wants to collapse based on the first field, the command should be:

```bash
woltka tools collapse -i input.biom -f 1 -m mapping.txt -o output.biom
```

But it wouldn't work, because Woltka mistakenly thought field code "1" means no field.

This bug is now fixed.