### PR TITLE
Fixed sample ID list bug

### DIFF
--- a/woltka/tests/test_workflow.py
+++ b/woltka/tests/test_workflow.py
@@ -231,6 +231,12 @@ class WorkflowTests(TestCase):
         exp = {join(self.tmpdir, f'S{i}.sam'): f'S{i}' for i in range(1, 4)}
         self.assertDictEqual(obs[1], exp)
 
+        # independent sample Id list file
+        obs = parse_samples(self.tmpdir, samples=fp)
+        self.assertListEqual(obs[0], ['S1', 'S2', 'S3'])
+        exp = {join(self.tmpdir, f'S{i}.sam'): f'S{i}' for i in range(1, 4)}
+        self.assertDictEqual(obs[1], exp)
+
         # some samples only
         obs = parse_samples(fp, samples='S1,S2')
         self.assertListEqual(obs[0], ['S1', 'S2'])

--- a/woltka/workflow.py
+++ b/woltka/workflow.py
@@ -365,7 +365,11 @@ def parse_samples(fp:        str,
     """
     # read sample Ids
     if samples:
-        samples = read_ids(samples) if isfile(samples) else samples.split(',')
+        if isfile(samples):
+            with openzip(samples) as fh:
+                samples = read_ids(fh)
+        else:
+            samples = samples.split(',')
         click.echo(f'Number of samples to include: {len(samples)}.')
 
     errmsg = 'Provided sample IDs and actual files are inconsistent.'


### PR DESCRIPTION
Addressed #163, thank @ProsperP for noting this.

Now the following command would work:

```bash
woltka classify -i input_dir -s metadata.tsv ... -o output.biom
```