### PR TITLE
Improve command-line interface

### DIFF
--- a/doc/collapse.md
+++ b/doc/collapse.md
@@ -5,13 +5,13 @@ The **profile collapsing** function is a lightweight and flexible addition to th
 Collapse features based on a mapping file:
 
 ```bash
-woltka tools collapse -i input.biom -m mapping.txt -o output.biom
+woltka collapse -i input.biom -m mapping.txt -o output.biom
 ```
 
 Collapse nested features to the first level:
 
 ```bash
-woltka tools collapse -i input.biom -e -f 1 -o output.biom
+woltka collapse -i input.biom -e -f 1 -o output.biom
 ```
 
 
@@ -127,7 +127,7 @@ Feature ID | Sample 1 | Sample 2 | Sample 3
 One can collapse the "species|gene" features into just species (regardless of gene) with:
 
 ```bash
-woltka tools collapse -i species_gene.tsv -f 1 -o species.tsv
+woltka collapse -i species_gene.tsv -f 1 -o species.tsv
 ```
 
 The output profile `species.tsv` is like:
@@ -145,7 +145,7 @@ Alternatively, one can use `-f 2` to collapse to genes (regardless of species).
 With a species-to-phylum mapping file `phylum.map`, one can collapse the first field (species):
 
 ```bash
-woltka tools collapse -i species_gene.tsv -f 1 -m phylum.map -o phylum_gene.tsv
+woltka collapse -i species_gene.tsv -f 1 -m phylum.map -o phylum_gene.tsv
 ```
 
 The output profile `phylum_gene.tsv` will be like:
@@ -160,7 +160,7 @@ Feature ID | Sample 1 | Sample 2 | Sample 3
 With a gene-to-biological process mapping file `process.map`, one can collapse the second field (gene):
 
 ```bash
-woltka tools collapse -i species_gene.tsv -f 2 -m process.map -o species_process.tsv
+woltka collapse -i species_gene.tsv -f 2 -m process.map -o species_process.tsv
 ```
 
 The output profile `species_process.tsv` will be like:
@@ -174,8 +174,8 @@ Feature ID | Sample 1 | Sample 2 | Sample 3
 One can combine the two operations:
 
 ```bash
-woltka tools collapse -i species_gene.tsv -f 1 -m phylum.map -o phylum_gene.tsv
-woltka tools collapse -i phylum_gene.tsv -f 2 -m process.map -o phylum_process.tsv
+woltka collapse -i species_gene.tsv -f 1 -m phylum.map -o phylum_gene.tsv
+woltka collapse -i phylum_gene.tsv -f 2 -m process.map -o phylum_process.tsv
 ```
 
 The output profile `phylum_process.tsv` will be like:
@@ -199,7 +199,7 @@ The `--nested` or `-e` flag instructs Woltka to treat feature IDs as nested. The
 For example, with an ORF table `orf.tsv`, one can do:
 
 ```bash
-woltka tools collapse -i orf.tsv -e -f 1 -o ogu.tsv
+woltka collapse -i orf.tsv -e -f 1 -o ogu.tsv
 ```
 
 This will collapse an ORF table into an [OGU table](ogu.md), in which only "G12" but not "_34" is retained.
@@ -220,7 +220,7 @@ Feature ID | Sample 1 | Sample 2 | Sample 3
 One can collapse them into 2-level EC numbers with:
 
 ```bash
-woltka tools collapse -i ec4.tsv -e -s "." -f 2 -o ec2.tsv
+woltka collapse -i ec4.tsv -e -s "." -f 2 -o ec2.tsv
 ```
 
 The output profile `ec2.tsv` is like:
@@ -246,7 +246,7 @@ Feature ID | Sample 1 | Sample 2
 One can collapse them into the class level with:
 
 ```bash
-woltka tools collapse -i free.tsv -e -s "; " -f 2 -o class.tsv
+woltka collapse -i free.tsv -e -s "; " -f 2 -o class.tsv
 ```
 
 The output profile `class.tsv` is like:
@@ -273,7 +273,7 @@ G000007845_1274
 With a genome-to-genus mapping file `genus.map`, one can collapse the first field (i.e., taxonomic analysis):
 
 ```bash
-woltka tools collapse -i orf.biom -e -f 1 -m genus.map -o genus_orf.biom
+woltka collapse -i orf.biom -e -f 1 -m genus.map -o genus_orf.biom
 ```
 
 The resulting feature IDs are like:
@@ -285,7 +285,7 @@ Bacillus|G000006785_1274
 With an ORF-to-UniRef mapping file `uniref.map`, one can collapse the second field (i.e., functional analysis):
 
 ```bash
-woltka tools collapse -i orf.biom -e -f 2 -m uniref.map -o ogu_uniref.biom
+woltka collapse -i orf.biom -e -f 2 -m uniref.map -o ogu_uniref.biom
 ```
 
 The resulting feature IDs are like:
@@ -297,9 +297,9 @@ G000006785|J9GI19
 One can execute the `collapse` command multiple times to collapse the first and second fields separately to achieve desired taxonomic and functional resolution. Note that starting from the second command, features are no longer nested.
 
 ```bash
-woltka tools collapse -i orf.biom -e -f 2 -m uniref.map -o ogu_uniref.biom
-woltka tools collapse -i ogu_uniref.biom -f 1 -m genus.map -o genus_uniref.biom
-woltka tools collapse -i genus_uniref.biom -f 2 -m uniref2go.map -o genus_go.biom
+woltka collapse -i orf.biom -e -f 2 -m uniref.map -o ogu_uniref.biom
+woltka collapse -i ogu_uniref.biom -f 1 -m genus.map -o genus_uniref.biom
+woltka collapse -i genus_uniref.biom -f 2 -m uniref2go.map -o genus_go.biom
 ...
 ```
 
@@ -314,7 +314,7 @@ EC:2.7.2.10
 One can collapse the 2nd level by using an enzyme-to-substrate mapping file `substrate.map`:
 
 ```bash
-woltka tools collapse -i ec4.tsv -e -f 2 -m substrate.map -o output.tsv
+woltka collapse -i ec4.tsv -e -f 2 -m substrate.map -o output.tsv
 ```
 
 The output feature IDs will be like:

--- a/doc/coverage.md
+++ b/doc/coverage.md
@@ -3,7 +3,7 @@
 The **coverage** command calculates the coverage -- percentage of features present in each sample over a pre-defined group of features -- of a profile.
 
 ```bash
-woltka tools coverage -i input.biom -m mapping.txt -o output.biom
+woltka coverage -i input.biom -m mapping.txt -o output.biom
 ```
 
 A typical use case is to assess the likelihoods of presence of **metabolic pathways** in each organism or community. Because a pathway consists of _multiple_ chemical **reactions** or functional **genes** connected to each other, the presence of some of them (even with high abundance) in the sample does not necessarily suggest that the entire pathway is viable. Only when all or a large proportion of them are found can we be more confident about this hypothesis.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -97,7 +97,7 @@ Yes. See [here](normalize.md) for methods.
 
 ### I ran Woltka separately on multiple subsets of data. Can I merge the results?
 
-Yes. The `woltka tools merge` command is for you. See [here](merge.md) for details.
+Yes. The `woltka merge` command is for you. See [here](merge.md) for details.
 
 ### Can Woltka report taxon names instead of TaxIDs when using NCBI taxonomy?
 

--- a/doc/filter.md
+++ b/doc/filter.md
@@ -3,7 +3,7 @@
 The **filter** command filters each feature in each sample based on the absolute or relative abundance of that feature in that particular sample. For example, the following command will drop features that are less than 0.01% abundant in each sample:
 
 ```bash
-woltka tools filter -i input.biom -o output.biom --min-percent 0.01
+woltka filter -i input.biom -o output.biom --min-percent 0.01
 ```
 
 This function is especially useful in shotgun metagenomics, where **very-low-abundance false positive assignments** are prevalent and can cause biases in downstream analyses ([Ye et al, 2019](https://www.cell.com/cell/fulltext/S0092-8674(19)30775-5)).

--- a/doc/kegg.md
+++ b/doc/kegg.md
@@ -29,7 +29,7 @@ This will generate multiple mapping files in the current directory. The filename
 **Step 3**: Use Woltka's [**collapse**](collapse.md) command to convert KO's to higher-level classification units. This command supports many-to-many mapping, because that's the nature of the relationships between functional units (e.g., genes vs pathways). For example, the following command will generate a profile of **reactions**:
 
 ```bash
-woltka tools collapse -i ko.tsv -m kegg/ko-to-reaction.txt -o reaction.tsv
+woltka collapse -i ko.tsv -m kegg/ko-to-reaction.txt -o reaction.tsv
 ```
 
 Once a reaction profile is generated, several mapping files help to find more information about the reactions, such as `reaction_name.txt`, `reaction_equation.txt` and `reaction_definition.txt`. Meanwhile several other one-to-many mapping files, such as `reaction-to-compound.txt`, `reaction-to-module.txt`, `reaction-to-rclass.txt` help to explore the data toward other classification levels. All are enabled by the `collapse` command.
@@ -37,7 +37,7 @@ Once a reaction profile is generated, several mapping files help to find more in
 **Step 4**: You may want to explore the completeness of individual reactions, modules and pathways. This can be achieved using Woltka's [**coverage**](coverage.md) command. For example:
 
 ```bash
-woltka tools coverage -i reaction.tsv -m kegg/module-to-reaction.txt -o module.cov.tsv
+woltka coverage -i reaction.tsv -m kegg/module-to-reaction.txt -o module.cov.tsv
 ```
 
 Differently from the last command, the **coverage** command generates a table, where cell values indicate the percentage of reactions required by each module found in each sample.

--- a/doc/merge.md
+++ b/doc/merge.md
@@ -3,7 +3,7 @@
 The **merge** command merges two or more profiles into one, while treating overlapping samples and features in an additive way. This is useful when the analysis includes multiple sets of input files (e.g., multiple sequencing runs).
 
 ```bash
-woltka tools merge -i input1.biom -i input2.biom -i input3.biom -o output.biom
+woltka merge -i input1.biom -i input2.biom -i input3.biom -o output.biom
 ```
 
 This command is different from QIIME 2's `qiime feature-table merge` command, as the latter can only handle unique sample IDs.

--- a/doc/metacyc.md
+++ b/doc/metacyc.md
@@ -41,7 +41,7 @@ Alternatively, one can split this command into two:
 
 ```bash
 woltka classify -i input_dir -c coords.txt.xz -o orf.biom
-woltka tools collapse -i orf.biom -m metacyc/protein.map.xz -n metacyc/protein_name.txt -o protein.biom
+woltka collapse -i orf.biom -m metacyc/protein.map.xz -n metacyc/protein_name.txt -o protein.biom
 ```
 
 
@@ -74,15 +74,15 @@ Using the following commands:
 
 ```bash
 # protein to enzrxn (enzymatic reaction):
-woltka tools collapse -i protein.biom -m metacyc/protein-to-enzrxn.txt -n metacyc/enzrxn_name.txt -o enzrxn.biom
+woltka collapse -i protein.biom -m metacyc/protein-to-enzrxn.txt -n metacyc/enzrxn_name.txt -o enzrxn.biom
 # enzrxn to reaction:
-woltka tools collapse -i enzrxn.biom -m metacyc/enzrxn-to-reaction.txt -n metacyc/reaction_name.txt -o reaction.biom
+woltka collapse -i enzrxn.biom -m metacyc/enzrxn-to-reaction.txt -n metacyc/reaction_name.txt -o reaction.biom
 # reaction to pathway:
-woltka tools collapse -i reaction.biom -m metacyc/reaction-to-pathway.txt -n metacyc/pathway_name.txt -o pathway.biom
+woltka collapse -i reaction.biom -m metacyc/reaction-to-pathway.txt -n metacyc/pathway_name.txt -o pathway.biom
 # pathway to super pathway:
-woltka tools collapse -i pathway.biom -m metacyc/pathway-to-super_pathway.txt -n metacyc/pathway_name.txt -o super_pathway.biom
+woltka collapse -i pathway.biom -m metacyc/pathway-to-super_pathway.txt -n metacyc/pathway_name.txt -o super_pathway.biom
 # super pathway (or pathway) to pathway type:
-woltka tools collapse -i super_pathway.biom -m metacyc/pathway_type.txt -n metacyc/all_class_name.txt -o pathway_type.biom
+woltka collapse -i super_pathway.biom -m metacyc/pathway_type.txt -n metacyc/all_class_name.txt -o pathway_type.biom
 ```
 
 The collapse command supports **many-to-many** mapping. For example, if one reaction is found in three pathways, each pathway will be counted **once**. In some instances (e.g., to retain compositionality of the profile), one may consider adding the `--divide` flag, which will instruct the program to count each pathway 1 / 3 times ([see details](collapse.md)).
@@ -95,7 +95,7 @@ It is usually important to assess how **completed**, in addition to how abundant
 Among the mapping files there are two files recording the composition of metabolic pathways in terms of **genes** and **reactions**. We recommend using the reaction mapping because there are duplicated gene IDs.
 
 ```bash
-woltka tools coverage -i reaction.biom -m pathway-to-reaction_list.txt -o pathway_coverage.biom
+woltka coverage -i reaction.biom -m pathway-to-reaction_list.txt -o pathway_coverage.biom
 ```
 
 The output file is a **coverage** table in which every cell value represents the percentage of member reactions of a particular pathway present in a particular sample.

--- a/doc/normalize.md
+++ b/doc/normalize.md
@@ -24,7 +24,7 @@ Woltka has two modes of normalization, each providing all four functions mention
 
 1. The normalization functions can be called as part of the main classification workflow (`woltka classify`), and directly output normalized profiles.
 
-2. One can perform normalization on profiles that are already generated (`woltka tools normalize`). This saves the need for re-running the workflow.
+2. One can perform normalization on profiles that are already generated (`woltka normalize`). This saves the need for re-running the workflow.
 
 There is a major advantage of normalization by subject size **during** classification, as detailed below. Other than that, the two modes produce mutually identical results. See below for some examples.
 
@@ -51,7 +51,7 @@ woltka classify --sizes size.map ...
 Or post classification (on existing profiles):
 
 ```bash
-woltka tools normalize --sizes size.map ...
+woltka normalize --sizes size.map ...
 ```
 
 A special case is during "coord-match" functional classification (see [details](ordina.md)), one can use a dot (`.`) instead of a mapping file. Woltka will read gene sizes from the gene coordinates file.
@@ -75,7 +75,7 @@ It is more convenient to scale up resulting values by a constant, such as one mi
 Examples (post classification):
 
 ```bash
-woltka tools normalize -i ogu.biom -m length.map --scale 1M -o ogu.cpm.biom
+woltka normalize -i ogu.biom -m length.map --scale 1M -o ogu.cpm.biom
 ```
 
 During classification:
@@ -141,7 +141,7 @@ The output values are fractions (like "0.05"). One can add `--scale 100` to conv
 On an existing profile:
 
 ```bash
-woltka tools normalize ... (without --sizes, automatically applies --frac)
+woltka normalize ... (without --sizes, automatically applies --frac)
 ```
 
 **Note**: These values are the fractions of reads assigned to each classification units versus all reads that are **assigned**. If you add `--unassigned`, the values become the fractions of reads versus all reads that are **aligned**. Woltka cannot calculate the fractions of reads versus the **original** sequencing data, since it processes alignment files instead of raw FastQ files. However, it isn't hard to do this calculation manually if you know the sequencing depth information.
@@ -149,5 +149,5 @@ woltka tools normalize ... (without --sizes, automatically applies --frac)
 This function can also convert an RPK functional profile (see above) to the unit of **TPM (transcripts per kilobase million)**:
 
 ```bash
-woltka tools normalize -i rpk.biom --scale 1M -o tpm.biom
+woltka normalize -i rpk.biom --scale 1M -o tpm.biom
 ```

--- a/doc/ordinal.md
+++ b/doc/ordinal.md
@@ -94,7 +94,7 @@ woltka classify -i indir -c coords.txt --sizes . --scale 1k --digits 3 -o rpk.bi
 One can further convert RPK into **TPM** (transcripts per kilobase million) by the following command, which divides individual RPK values by the total RPK per sample, and multiplies them by 1 million.
 
 ```bash
-woltka tools normalize -i rpk.biom --scale 1M -o tpm.biom
+woltka normalize -i rpk.biom --scale 1M -o tpm.biom
 ```
 
 - **Note**: This TPM is equivalent to HUMAnN's **CPM** (copies per million; not to be confused with counts per million, see HUMAnN's [documentation](https://github.com/biobakery/humann#humann_renorm_table) for details). However see an important [note](classify.md@considerations) here.
@@ -133,23 +133,23 @@ An alternative way is to only generate the gene-level profile using the `classif
 
 ```bash
 woltka classify -i indir -c coords.txt -o gene.biom
-woltka tools collapse -i gene.biom     -m gene-to-protein.map     -o protein.biom
-woltka tools collapse -i protein.biom  -m protein-to-enzrxn.map   -o enzrxn.biom
-woltka tools collapse -i enzrxn.biom   -m enzrxn-to-reaction.map  -o reaction.biom
-woltka tools collapse -i reaction.biom -m reaction-to-pathway.map -o pathway.biom
-woltka tools collapse -i pathway.biom  -m pathway-to-super.map    -o super.biom
+woltka collapse -i gene.biom     -m gene-to-protein.map     -o protein.biom
+woltka collapse -i protein.biom  -m protein-to-enzrxn.map   -o enzrxn.biom
+woltka collapse -i enzrxn.biom   -m enzrxn-to-reaction.map  -o reaction.biom
+woltka collapse -i reaction.biom -m reaction-to-pathway.map -o pathway.biom
+woltka collapse -i pathway.biom  -m pathway-to-super.map    -o super.biom
 ```
 
 In the [WoL data release](wol.md), there are pre-built mappings to UniRef, GO, MetaCyc, KEGG and more.
 
-- Note: For some databases, such as [MetaCyc](https://metacyc.org), you might encounter an error regarding `AssertionError: Conflicting values found for ...`. This is likely because some classification units were simultaneously assigned to multiple ranks in the database, which causes conflicts in the Woltka workflow. In this case we recommend generating the gene-level profile with `woltka classify`, and then collapsing to individual levels one at a time with `woltka tools collapse`.
+- Note: For some databases, such as [MetaCyc](https://metacyc.org), you might encounter an error regarding `AssertionError: Conflicting values found for ...`. This is likely because some classification units were simultaneously assigned to multiple ranks in the database, which causes conflicts in the Woltka workflow. In this case we recommend generating the gene-level profile with `woltka classify`, and then collapsing to individual levels one at a time with `woltka collapse`.
 
 ## Pathway coverage
 
 It is a frequent goal to assess the abundances of individual metabolic pathways in the microbiome. However, a pathway only makes sense when all (or an essential subset) of its member enzymes are present. Woltka can calculate the percent **coverage** of pathways based on the presence/absence of member genes as follows:
 
 ```bash
-woltka tools coverage -i gene.biom -m pathway-to-genes.txt -o pathway_coverage.biom
+woltka coverage -i gene.biom -m pathway-to-genes.txt -o pathway_coverage.biom
 ```
 
 See [here](coverage.md) for details of coverage calculation.

--- a/doc/perform.md
+++ b/doc/perform.md
@@ -74,13 +74,13 @@ You may have hundreds of alignment files to crunch, and dozens of compute nodes 
 Woltka provides a utility to conveniently merge multiple profiles:
 
 ```bash
-woltka tools merge -i table1.biom -i table2.biom -i table3.biom ... -o merged.biom
+woltka merge -i table1.biom -i table2.biom -i table3.biom ... -o merged.biom
 ```
 
 Or:
 
 ```bash
-woltka tools merge -i <directory containing lots of .biom/tsv> -o merged.biom/tsv
+woltka merge -i <directory containing lots of .biom/tsv> -o merged.biom/tsv
 ```
 
 Note: If you plan to run Woltka on each individual file (not multiplexed), you should add `--no-demux` to the command, otherwise Woltka will attempted to demultiplex it. Example:

--- a/doc/wol.md
+++ b/doc/wol.md
@@ -173,26 +173,26 @@ mcdir=function/metacyc
 Collapse ORFs into MetaCyc proteins:
 
 ```bash
-woltka tools collapse -i gene.biom -m $mc/protein.map.xz -n $mc/protein_name.txt -o protein.biom
+woltka collapse -i gene.biom -m $mc/protein.map.xz -n $mc/protein_name.txt -o protein.biom
 ```
 - Here `-i`, `-o`, `-m` and `-n` are abbreviations for `--input`, `--output`, `--map` and `--names`.
 
 Collapse proteins into enzymatic reactions:
 
 ```bash
-woltka tools collapse -i protein.biom -m $mc/protein-to-enzrxn.txt -n $mc/enzrxn_name.txt -o enzrxn.biom
+woltka collapse -i protein.biom -m $mc/protein-to-enzrxn.txt -n $mc/enzrxn_name.txt -o enzrxn.biom
 ```
 
 Collapse enzymatic reactions into reactions:
 
 ```bash
-woltka tools collapse -i enzrxn.biom -m $mc/enzrxn-to-reaction.txt -n $mc/reaction_name.txt -o reaction.biom
+woltka collapse -i enzrxn.biom -m $mc/enzrxn-to-reaction.txt -n $mc/reaction_name.txt -o reaction.biom
 ```
 
 Collapse reactions to metabolic pathways:
 
 ```bash
-woltka tools collapse -i reaction.biom -m $mc/reaction-to-pathway.txt -n $mc/pathway_name.txt -o pathway.biom
+woltka collapse -i reaction.biom -m $mc/reaction-to-pathway.txt -n $mc/pathway_name.txt -o pathway.biom
 ```
 
 So on so forth. See [here](metacyc.md) for a graph of all available collapsing directions.
@@ -260,7 +260,7 @@ In the output table, features will be like `Escherichia|K00133`, `Salmonella|K00
 With a stratified taxonomic/functional profile, one may still perform further [collapsing](#method-2) using one of the two systems. For example:
 
 ```bash
-woltka tools collapse -f 2 -i ko_by_genus.biom -m ko/ko-to-go.txt -o go_by_genus.biom
+woltka collapse -f 2 -i ko_by_genus.biom -m ko/ko-to-go.txt -o go_by_genus.biom
 ```
 
 The parameter `-f 2` instructs the program to collapse by the second field of each feature (e.g., `K00133` of `Escherichia|K00133`). See [here](collapse.md#stratification) for details.

--- a/doc/wolsop.sh
+++ b/doc/wolsop.sh
@@ -116,11 +116,11 @@ if [ "$go" == yes ]; then
 
   # by domain
   for domain in all component function process; do
-    woltka tools collapse -m $go/$domain.map.xz -n $go/name.txt \
+    woltka collapse -m $go/$domain.map.xz -n $go/name.txt \
       -i ../uniref.$fmt -o $domain.$fmt
 
     # GO slim (generic)
-    woltka tools collapse -m $go/generic/$domain.map -n $go/name.txt \
+    woltka collapse -m $go/generic/$domain.map -n $go/name.txt \
       -i $domain.$fmt -o $domain.generic.$fmt
   done
   cd ..
@@ -139,63 +139,63 @@ if [ "$metacyc" == yes ]; then
   cd metacyc
 
   # ORF to protein
-  woltka tools collapse -m $mc/protein.map.xz -n $mc/protein_name.txt \
+  woltka collapse -m $mc/protein.map.xz -n $mc/protein_name.txt \
     -i ../orf.$fmt -o protein.$fmt
 
   # protein to enzrxn (enzymatic reaction)
-  woltka tools collapse -m $mc/protein-to-enzrxn.txt -n $mc/enzrxn_name.txt \
+  woltka collapse -m $mc/protein-to-enzrxn.txt -n $mc/enzrxn_name.txt \
     -i protein.$fmt -o enzrxn.$fmt
 
   # enzrxn to reaction
-  woltka tools collapse -m $mc/enzrxn-to-reaction.txt -n $mc/reaction_name.txt \
+  woltka collapse -m $mc/enzrxn-to-reaction.txt -n $mc/reaction_name.txt \
     -i enzrxn.$fmt -o reaction.$fmt
 
   # reaction to pathway
-  woltka tools collapse -m $mc/reaction-to-pathway.txt -n $mc/pathway_name.txt \
+  woltka collapse -m $mc/reaction-to-pathway.txt -n $mc/pathway_name.txt \
     -i reaction.$fmt -o pathway.$fmt
 
   # pathway to super pathway
-  woltka tools collapse -m $mc/pathway-to-super_pathway.txt -n $mc/pathway_name.txt \
+  woltka collapse -m $mc/pathway-to-super_pathway.txt -n $mc/pathway_name.txt \
     -i pathway.$fmt -o super_pathway.$fmt
 
   # super pathway (or pathway) to pathway type
-  woltka tools collapse -m $mc/pathway_type.txt -n $mc/all_class_name.txt \
+  woltka collapse -m $mc/pathway_type.txt -n $mc/all_class_name.txt \
   -i super_pathway.$fmt -o pathway_type.$fmt
 
   # protein to gene
-  woltka tools collapse -m $mc/protein-to-gene.txt -n $mc/gene_name.txt \
+  woltka collapse -m $mc/protein-to-gene.txt -n $mc/gene_name.txt \
     -i protein.$fmt -o gene.$fmt
 
   # protein to go
-  woltka tools collapse -m $mc/protein-to-go.txt \
+  woltka collapse -m $mc/protein-to-go.txt \
     -i protein.$fmt -o go.$fmt
 
   # enzrxn to regulation to regulator
-  woltka tools collapse -m $mc/enzrxn-to-regulation.txt \
+  woltka collapse -m $mc/enzrxn-to-regulation.txt \
     -i enzrxn.$fmt -o regulation.$fmt
-  woltka tools collapse -m $mc/regulation-to-regulator.txt -n $mc/compound_name.txt \
+  woltka collapse -m $mc/regulation-to-regulator.txt -n $mc/compound_name.txt \
     -i regulation.$fmt -o regulator.$fmt
 
   # reaction to compound (left and right)
   for side in left right; do
-    woltka tools collapse -m $mc/reaction-to-${side}_compound.txt -n $mc/compound_name.txt \
+    woltka collapse -m $mc/reaction-to-${side}_compound.txt -n $mc/compound_name.txt \
       -i reaction.$fmt -o ${side}_compound.$fmt
 
     # compound type
-    woltka tools collapse -m $mc/compound_type.txt -n $mc/all_class_name.txt \
+    woltka collapse -m $mc/compound_type.txt -n $mc/all_class_name.txt \
       -i ${side}_compound.$fmt -o ${side}_compound_type.$fmt
   done
 
   # compound and type (both sides)
-  woltka tools merge -i left_compound.$fmt -i right_compound.$fmt -o compound.$fmt
-  woltka tools merge -i left_compound_type.$fmt -i right_compound_type.$fmt -o compound_type.$fmt
+  woltka merge -i left_compound.$fmt -i right_compound.$fmt -o compound.$fmt
+  woltka merge -i left_compound_type.$fmt -i right_compound_type.$fmt -o compound_type.$fmt
 
   # reaction to EC
-  woltka tools collapse -m $mc/reaction-to-ec.txt \
+  woltka collapse -m $mc/reaction-to-ec.txt \
     -i reaction.$fmt -o ec.$fmt
 
   # pathway coverage (by reaction)
-  woltka tools coverage -m $mc/pathway-to-reaction_list.txt \
+  woltka coverage -m $mc/pathway-to-reaction_list.txt \
     -i reaction.$fmt -o pathway_coverage.$fmt
 
   cd ..
@@ -216,66 +216,66 @@ if [ -d "$kegg" ]; then
 
   # entrance
   # UniRef to KO
-  woltka tools collapse -m $db/function/kegg/ko.map.xz -n $db/function/kegg/ko.name \
+  woltka collapse -m $db/function/kegg/ko.map.xz -n $db/function/kegg/ko.name \
     -i ../uniref.$fmt -o ko.$fmt
 
   # main cascade
   # KO to reaction
-  woltka tools collapse -m $ke/ko-to-reaction.txt -n $ke/reaction_name.txt \
+  woltka collapse -m $ke/ko-to-reaction.txt -n $ke/reaction_name.txt \
     -i ko.$fmt -o reaction.$fmt
 
   # reaction to module
-  woltka tools collapse -m $ke/reaction-to-module.txt -n $ke/module_name.txt \
+  woltka collapse -m $ke/reaction-to-module.txt -n $ke/module_name.txt \
     -i reaction.$fmt -o module.$fmt
 
   # module to pathway
-  woltka tools collapse -m $ke/module-to-pathway.txt -n $ke/pathway_name.txt \
+  woltka collapse -m $ke/module-to-pathway.txt -n $ke/pathway_name.txt \
     -i module.$fmt -o pathway.$fmt
 
   # classes
   # reaction to rclass
-  woltka tools collapse -m $ke/reaction-to-rclass.txt -n $ke/rclass_name.txt \
+  woltka collapse -m $ke/reaction-to-rclass.txt -n $ke/rclass_name.txt \
     -i reaction.$fmt -o rclass.$fmt
 
   # module class
-  woltka tools collapse -m $ke/module-to-class.txt \
+  woltka collapse -m $ke/module-to-class.txt \
     -i module.$fmt -o module_class.$fmt
 
   # pathway class
-  woltka tools collapse -m $ke/pathway-to-class.txt \
+  woltka collapse -m $ke/pathway-to-class.txt \
     -i pathway.$fmt -o pathway_class.$fmt
 
   # compounds
   for side in left right; do
-    woltka tools collapse -m $ke/reaction-to-${side}_compound.txt -n $ke/compound_name.txt \
+    woltka collapse -m $ke/reaction-to-${side}_compound.txt -n $ke/compound_name.txt \
       -i reaction.$fmt -o ${side}_compound.$fmt
   done
-  woltka tools merge -i left_compound.$fmt -i right_compound.$fmt -o compound.$fmt
+  woltka merge -i left_compound.$fmt -i right_compound.$fmt -o compound.$fmt
 
   # extended
   # KO to EC
-  woltka tools collapse -m $ke/ko-to-ec.txt \
+  woltka collapse -m $ke/ko-to-ec.txt \
     -i ko.$fmt -o ec.$fmt
 
   # KO to GO
-  woltka tools collapse -m $ke/ko-to-go.txt \
+  woltka collapse -m $ke/ko-to-go.txt \
     -i ko.$fmt -o go.$fmt
 
   # KO to COG
-  woltka tools collapse -m $ke/ko-to-cog.txt \
+  woltka collapse -m $ke/ko-to-cog.txt \
     -i ko.$fmt -o cog.$fmt
 
   # KO to disease
-  woltka tools collapse -m $ke/ko-to-disease.txt -n $ke/disease_name.txt \
+  woltka collapse -m $ke/ko-to-disease.txt -n $ke/disease_name.txt \
     -i ko.$fmt -o disease.$fmt
 
   # coverage
   # module coverage by reaction
-  woltka tools coverage -m $ke/module-to-reaction.txt \
+  woltka coverage -m $ke/module-to-reaction.txt \
     -i reaction.$fmt -o module_coverage.$fmt
 
   # pathway coverage by module
-  woltka tools coverage -m $ke/pathway-to-module.txt \
+  woltka coverage -m $ke/pathway-to-module.txt \
     -i module.$fmt -o pathway_coverage.$fmt
 
   cd ..

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -175,88 +175,12 @@ def cli():
     '--no-exe', is_flag=True,
     help='Disable calling external programs for decompression.')
 def classify_cmd(**kwargs):
-    """Generate a profile of samples based on a classification system.
+    """Main classification workflow: Alignments => profile(s).
     """
     workflow(**kwargs)
 
 
-# `tools` provides utilities for working with alignments, maps and profiles
-
-@cli.group('tools', cls=NaturalOrderGroup)
-def tools():
-    """Utilities for working with alignments, maps and profiles.
-    """
-    pass  # pragma: no cover
-
-
-@tools.command('normalize')
-@click.option(
-    '--input', '-i', 'input_fp', required=True,
-    type=click.Path(exists=True, dir_okay=False),
-    help='Path to input profile.')
-@click.option(
-    '--output', '-o', 'output_fp', required=True,
-    type=click.Path(writable=True, dir_okay=False),
-    help='Path to output profile.')
-@click.option(
-    '--sizes', '-z', 'sizes_fp',
-    type=click.Path(exists=True, dir_okay=False),
-    help=('Path to mapping of feature sizes, by which values will be divided. '
-          'If omitted, will divide values by sum per sample.'))
-@click.option(
-    '--scale', '-s', type=click.STRING,
-    help='Scale values by this factor. Accepts "k", "M" suffixes.')
-@click.option(
-    '--digits', '-d', type=click.IntRange(0, 10),
-    help=('Round values to this number of digits after the decimal point. If '
-          'omitted, will keep decimal precision of input profile.'))
-@click.pass_context
-def normalize_cmd(ctx, **kwargs):
-    """Normalize a profile to fractions or by feature sizes.
-    """
-    normalize_wf(**kwargs)
-
-
-@tools.command('filter')
-@click.option(
-    '--input', '-i', 'input_fp', required=True,
-    type=click.Path(exists=True, dir_okay=False),
-    help='Path to input profile.')
-@click.option(
-    '--output', '-o', 'output_fp', required=True,
-    type=click.Path(writable=True, dir_okay=False),
-    help='Path to output profile.')
-@click.option(
-    '--min-count', '-c', type=click.IntRange(min=1),
-    help='Per-sample minimum count threshold.')
-@click.option(
-    '--min-percent', '-p', type=click.FLOAT,
-    help='Per-sample minimum percentage threshold.')
-@click.pass_context
-def filter_cmd(ctx, **kwargs):
-    """Filter a profile by per-sample abundance.
-    """
-    filter_wf(**kwargs)
-
-
-@tools.command('merge')
-@click.option(
-    '--input', '-i', 'input_fps', required=True, multiple=True,
-    type=click.Path(exists=True),
-    help=('Path to input profiles or directories containing profiles. Can '
-          'accept multiple paths.'))
-@click.option(
-    '--output', '-o', 'output_fp', required=True,
-    type=click.Path(writable=True, dir_okay=False),
-    help='Path to output profile.')
-@click.pass_context
-def merge_cmd(ctx, **kwargs):
-    """Merge multiple profiles into one profile.
-    """
-    merge_wf(**kwargs)
-
-
-@tools.command('collapse')
+@cli.command('collapse')
 @click.option(
     '--input', '-i', 'input_fp', required=True,
     type=click.Path(exists=True, dir_okay=False),
@@ -289,14 +213,77 @@ def merge_cmd(ctx, **kwargs):
 @click.option(
     '--names', '-n', 'names_fp', type=click.Path(exists=True),
     help='Names of target features to append to the output profile.')
-@click.pass_context
-def collapse_cmd(ctx, **kwargs):
-    """Collapse a profile based on feature mapping.
+def collapse_cmd(**kwargs):
+    """Collapse a profile by feature mapping and/or hierarchy.
     """
     collapse_wf(**kwargs)
 
 
-@tools.command('coverage')
+@cli.command('normalize')
+@click.option(
+    '--input', '-i', 'input_fp', required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help='Path to input profile.')
+@click.option(
+    '--output', '-o', 'output_fp', required=True,
+    type=click.Path(writable=True, dir_okay=False),
+    help='Path to output profile.')
+@click.option(
+    '--sizes', '-z', 'sizes_fp',
+    type=click.Path(exists=True, dir_okay=False),
+    help=('Path to mapping of feature sizes, by which values will be divided. '
+          'If omitted, will divide values by sum per sample.'))
+@click.option(
+    '--scale', '-s', type=click.STRING,
+    help='Scale values by this factor. Accepts "k", "M" suffixes.')
+@click.option(
+    '--digits', '-d', type=click.IntRange(0, 10),
+    help=('Round values to this number of digits after the decimal point. If '
+          'omitted, will keep decimal precision of input profile.'))
+def normalize_cmd(**kwargs):
+    """Normalize a profile to fractions and/or by feature sizes.
+    """
+    normalize_wf(**kwargs)
+
+
+@cli.command('filter')
+@click.option(
+    '--input', '-i', 'input_fp', required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help='Path to input profile.')
+@click.option(
+    '--output', '-o', 'output_fp', required=True,
+    type=click.Path(writable=True, dir_okay=False),
+    help='Path to output profile.')
+@click.option(
+    '--min-count', '-c', type=click.IntRange(min=1),
+    help='Per-sample minimum count threshold.')
+@click.option(
+    '--min-percent', '-p', type=click.FLOAT,
+    help='Per-sample minimum percentage threshold.')
+def filter_cmd(**kwargs):
+    """Filter a profile by per-sample abundance.
+    """
+    filter_wf(**kwargs)
+
+
+@cli.command('merge')
+@click.option(
+    '--input', '-i', 'input_fps', required=True, multiple=True,
+    type=click.Path(exists=True),
+    help=('Path to input profiles or directories containing profiles. Can '
+          'accept multiple paths.'))
+@click.option(
+    '--output', '-o', 'output_fp', required=True,
+    type=click.Path(writable=True, dir_okay=False),
+    help='Path to output profile.')
+def merge_cmd(**kwargs):
+    """Merge multiple profiles into one profile.
+    """
+    merge_wf(**kwargs)
+
+
+@cli.command('coverage')
 @click.option(
     '--input', '-i', 'input_fp', required=True,
     type=click.Path(exists=True, dir_okay=False),
@@ -320,8 +307,7 @@ def collapse_cmd(ctx, **kwargs):
 @click.option(
     '--names', '-n', 'names_fp', type=click.Path(exists=True),
     help='Names of feature groups to append to the coverage table.')
-@click.pass_context
-def coverage_cmd(ctx, **kwargs):
+def coverage_cmd(**kwargs):
     """Calculate per-sample coverage of feature groups.
     """
     coverage_wf(**kwargs)

--- a/woltka/cli.py
+++ b/woltka/cli.py
@@ -25,15 +25,22 @@ class NaturalOrderGroup(click.Group):
         return self.commands.keys()
 
 
+GRP_KA = dict(
+    cls=NaturalOrderGroup,
+    context_settings=dict(help_option_names=['-h', '--help']))
+CMD_KA = dict(
+    no_args_is_help=True)
+
+
 @click.version_option(__version__)
-@click.group(cls=NaturalOrderGroup)
+@click.group(**GRP_KA)
 def cli():
+    """Woltka: a versatile meta'omic data classifier.
+    """
     pass  # pragma: no cover
 
 
-# `classify` invokes the main classification workflow
-
-@cli.command('classify')
+@cli.command('classify', **CMD_KA)
 # input and output
 @click.option(
     '--input', '-i', 'input_fp', required=True, type=click.Path(
@@ -180,7 +187,7 @@ def classify_cmd(**kwargs):
     workflow(**kwargs)
 
 
-@cli.command('collapse')
+@cli.command('collapse', **CMD_KA)
 @click.option(
     '--input', '-i', 'input_fp', required=True,
     type=click.Path(exists=True, dir_okay=False),
@@ -219,7 +226,7 @@ def collapse_cmd(**kwargs):
     collapse_wf(**kwargs)
 
 
-@cli.command('normalize')
+@cli.command('normalize', **CMD_KA)
 @click.option(
     '--input', '-i', 'input_fp', required=True,
     type=click.Path(exists=True, dir_okay=False),
@@ -246,7 +253,7 @@ def normalize_cmd(**kwargs):
     normalize_wf(**kwargs)
 
 
-@cli.command('filter')
+@cli.command('filter', **CMD_KA)
 @click.option(
     '--input', '-i', 'input_fp', required=True,
     type=click.Path(exists=True, dir_okay=False),
@@ -267,7 +274,7 @@ def filter_cmd(**kwargs):
     filter_wf(**kwargs)
 
 
-@cli.command('merge')
+@cli.command('merge', **CMD_KA)
 @click.option(
     '--input', '-i', 'input_fps', required=True, multiple=True,
     type=click.Path(exists=True),
@@ -283,7 +290,7 @@ def merge_cmd(**kwargs):
     merge_wf(**kwargs)
 
 
-@cli.command('coverage')
+@cli.command('coverage', **CMD_KA)
 @click.option(
     '--input', '-i', 'input_fp', required=True,
     type=click.Path(exists=True, dir_okay=False),

--- a/woltka/tests/data/README.md
+++ b/woltka/tests/data/README.md
@@ -62,7 +62,7 @@ woltka classify \
 `bowtie2.free.1p.tsv`: [Filter](../../../doc/filter.md) out features with <1% per-sample abundance.
 
 ```bash
-woltka tools filter \
+woltka filter \
   --input output/bowtie2.free.tsv \
   --min-percent 1 \
   --output bowtie2.free.1p.tsv
@@ -175,7 +175,7 @@ woltka classify \
 `merged.process.tsv`: [Merge](../../../doc/merge.md) two profiles.
 
 ```bash
-woltka tools merge \
+woltka merge \
   --input output/burst.process.tsv \
   --input output/split.process.tsv \
   --output merged.process.tsv
@@ -243,7 +243,7 @@ woltka classify \
 Or, instead of doing the one-step classification workflow, [collapse](../../../doc/collapse.md) an existing per-gene profile into a UniRef profile.
 
 ```bash
-woltka tools collapse \
+woltka collapse \
   --input output/truth.gene.tsv \
   --map function/nucl/uniref.map.xz \
   --names function/uniref/uniref.names.xz \
@@ -253,7 +253,7 @@ woltka tools collapse \
 `truth.goslim.tsv`: Further collapse the UniRef profile into a [GO Slim](https://www.ebi.ac.uk/QuickGO/help/slims) profile. The program can handle one-to-many mappings (e.g., one GO term can be assigned to multiple GO Slim terms).
 
 ```bash
-woltka tools collapse \
+woltka collapse \
   --input output/truth.uniref.tsv \
   --map function/go/goslim.tsv.xz \
   --names function/go/name.txt.xz \


### PR DESCRIPTION
Modified CLI. Now the `tools` menu is gone. All commands are raised to the main interface. For example, `woltka tools collapse` becomes `woltka collapse`. Also let any command show help information if no parameter is given.