### PR TITLE
Upgrading to version 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## Version 0.1.5 (12/24/2022)
+
+### Changed
+- Modified the command-line interface. Sub-commands under the `tools` menu were raised to the main menu. For example, `woltka tools collapse` now becomes `woltka collapse` (#176). The `tools` menus is still kept for backward compatibility (#177).
+- Updated installation protocol. Now Woltka can be Conda-installed without explicit pre-installation of biom-format (#174).
+- Improved efficiency of handling BIOM tables (#171, #175).
+
+### Added
+- Upgraded the `collapse` command. Now it can collapse using internal hierarchies of feature IDs, such as genome-gene pairs, taxonomic lineages, and EC numbers. This upgrade enables stratified taxonomic/functional analysis of coord-matching ORF tables, without explicitly stratifying them during the classification step (which otherwise is time and space-consuming). The output should be identical to the that of the old method (#173).
+
+### Fixed
+- Fixed a bug in parsing sample ID lists (#164).
+
+
 ## Version 0.1.4 (04/27/2022)
 
 ### Changed

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -13,7 +13,7 @@ The former. Woltka **exhaustively** captures all valid matches from the alignmen
 
 ### Are Woltka results consistent across versions?
 
-To date, all Woltka versions (0.1.0 to 0.1.4) generate **identical** output files given the same setting. Later versions are more efficient and have more features, though.
+To date, all Woltka versions (0.1.0 to 0.1.5) generate **identical** output files given the same setting. Later versions are more efficient and have more features, though.
 
 ### How many CPU cores does Woltka use?
 

--- a/woltka/__init__.py
+++ b/woltka/__init__.py
@@ -9,8 +9,8 @@
 # ----------------------------------------------------------------------------
 
 __name__ = 'woltka'
-__description__ = 'versatile metagenome classifier'
-__version__ = '0.1.4'
+__description__ = 'versatile meta-omic data classifier'
+__version__ = '0.1.5'
 __license__ = 'BSD-3-Clause'
 __author__ = 'Qiyun Zhu'
 __email__ = 'qiyunzhu@gmail.com'


### PR DESCRIPTION
See change log for details. Most importantly, the `collapse` command has been upgraded to support taxonomic/functional stratification of ORF tables (i.e., the "per-gene" tables generated in Qiita), without the need of running classification twice. @droush @wasade @antgonza