### PR TITLE
BUG: Ignore hidden files when reading directory

### DIFF
--- a/woltka/file.py
+++ b/woltka/file.py
@@ -11,10 +11,10 @@
 """Functions for handling input and output files.
 """
 
-from os import listdir
 from os.path import basename, dirname, splitext, isfile, join
 from shutil import which
 from subprocess import Popen, PIPE
+import glob
 import gzip
 import bz2
 import lzma
@@ -277,20 +277,20 @@ def id2file_from_dir(dir_, ext=None, ids=None):
     Notes
     -----
     Only top-level directory is searched. Only files but not subdirectories are
-    considered.
+    considered. Hidden files will be ignored.
     """
     res = {}
-    for fname in listdir(dir_):
-        if isfile(join(dir_, fname)):
+    for fname in glob.glob(join(dir_, '*')):
+        if isfile(fname):
             try:
-                id_ = file2stem(fname, ext)
+                id_ = path2stem(fname, ext)
             except ValueError:
                 continue
             if ids and id_ not in ids:
                 continue
             if id_ in res:
                 raise ValueError(f'Ambiguous files for ID: "{id_}".')
-            res[id_] = fname
+            res[id_] = basename(fname)
     return res
 
 


### PR DESCRIPTION
These are some proposed changes to avoid trying to parse hidden files. I ran into this issue in macOS when inputing a directory where a hidden file `.DS_Store` file had been created by the OS.

```
Input directory: sams/.
Number of alignment files to read: 11.
Demultiplexing: off.
Constructing classification system...
  Parsing Newick tree file: tree.nwk... Done.
Classification system constructed.
  Total number of classification units: 20603.
Classification will operate on these ranks: free.
Parsing alignment file .DS_Store Traceback (most recent call last):
  File "/Users/yoshiki/miniconda3/envs/mg/bin/woltka", line 8, in <module>
    sys.exit(cli())
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/woltka/cli.py", line 188, in classify_cmd
    workflow(**kwargs)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/woltka/workflow.py", line 137, in workflow
    zippers, outcov_dir)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/woltka/workflow.py", line 293, in classify
    for qryque, subque in mapper(fh, fmt=fmt, n=chunk):
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/woltka/align.py", line 58, in plain_mapper
    fmt, head = (fmt, []) if fmt else infer_align_format(fh)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/woltka/align.py", line 204, in infer_align_format
    line = next(fh)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 3131: invalid start byte
```